### PR TITLE
feat: Meshtastic lockdown support, region fix, proto upgrade

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@
 
 buildscript {
 
-    ext.PLUGIN_VERSION = "0.2"
+    ext.PLUGIN_VERSION = "1.0"
     ext.ATAK_VERSION = "5.5.0"
 
     def takdevVersion = '3.+'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -311,6 +311,9 @@ dependencies {
     implementation 'androidx.core:core:1.15.0'
     implementation 'androidx.lifecycle:lifecycle-service:2.8.7'
 
+    // EncryptedSharedPreferences for the lockdown passphrase cache
+    implementation 'androidx.security:security-crypto:1.1.0-alpha06'
+
     // EXI library for XML processing
     implementation 'com.siemens.ct.exi:exificient:1.0.7'
 

--- a/app/src/main/java/com/atakmap/android/pluginmeshtastic/MeshtasticDropDownReceiver.java
+++ b/app/src/main/java/com/atakmap/android/pluginmeshtastic/MeshtasticDropDownReceiver.java
@@ -24,8 +24,12 @@ import com.atakmap.android.dropdown.DropDown;
 import com.atakmap.android.dropdown.DropDownReceiver;
 import com.atakmap.android.maps.MapView;
 import com.atakmap.android.pluginmeshtastic.meshtastic.AtakMeshtasticBridge;
+import com.atakmap.android.pluginmeshtastic.meshtastic.LockdownState;
+import com.atakmap.android.pluginmeshtastic.meshtastic.LockdownTokenInfo;
 import com.atakmap.android.pluginmeshtastic.meshtastic.MeshtasticBleScanner;
 import com.atakmap.android.pluginmeshtastic.meshtastic.MeshtasticManager;
+import android.text.InputType;
+import android.widget.LinearLayout;
 import com.atakmap.android.pluginmeshtastic.plugin.R;
 import com.atakmap.coremap.log.Log;
 
@@ -118,6 +122,14 @@ public class MeshtasticDropDownReceiver extends DropDownReceiver implements Drop
     private long lastRssiRequest = 0;
     private static final long RSSI_REQUEST_INTERVAL_MS = 5000; // Request RSSI every 5 seconds
 
+    // Lockdown UI state
+    private AlertDialog passphraseDialog;
+    private AlertDialog backoffDialog;
+    private Runnable backoffTickRunnable;
+    private TextView lockdownStatusText;
+    private Button lockNowButton;
+    private LockdownState currentLockdownState = LockdownState.None.INSTANCE;
+
     public MeshtasticDropDownReceiver(MapView mapView, Context context, AtakMeshtasticBridge bridge) {
         super(mapView);
         this.pluginContext = context;
@@ -139,6 +151,181 @@ public class MeshtasticDropDownReceiver extends DropDownReceiver implements Drop
 
         // Start observing scan results immediately to support autoconnect
         observeScanResults();
+
+        // Wire the lockdown UI (passphrase dialog, Lock Now button, status text).
+        initializeLockdownUi();
+    }
+
+    private void initializeLockdownUi() {
+        lockdownStatusText = templateView.findViewById(R.id.lockdown_status_text);
+        lockNowButton = templateView.findViewById(R.id.btn_lock_now);
+        if (lockNowButton != null) {
+            lockNowButton.setOnClickListener(v -> confirmAndLockNow());
+        }
+        meshtasticBridge.setLockdownListener((state, token) -> uiHandler.post(() -> onLockdownState(state, token)));
+    }
+
+    private void onLockdownState(LockdownState state, LockdownTokenInfo token) {
+        currentLockdownState = state;
+        if (lockdownStatusText != null) {
+            lockdownStatusText.setText(formatLockdownStatus(state, token));
+        }
+        if (state instanceof LockdownState.NeedsProvision) {
+            dismissBackoffDialog();
+            showPassphraseDialog(true);
+        } else if (state instanceof LockdownState.Locked) {
+            dismissBackoffDialog();
+            showPassphraseDialog(false);
+        } else if (state instanceof LockdownState.UnlockFailed) {
+            dismissBackoffDialog();
+            Toast.makeText(getMapView().getContext(), "Wrong passphrase", Toast.LENGTH_SHORT).show();
+            showPassphraseDialog(false);
+        } else if (state instanceof LockdownState.UnlockBackoff) {
+            dismissPassphraseDialog();
+            int seconds = ((LockdownState.UnlockBackoff) state).getBackoffSeconds();
+            showBackoffDialog(seconds);
+        } else if (state instanceof LockdownState.Unlocked) {
+            dismissPassphraseDialog();
+            dismissBackoffDialog();
+            Toast.makeText(getMapView().getContext(), "Device unlocked", Toast.LENGTH_SHORT).show();
+        } else if (state instanceof LockdownState.LockNowAcknowledged) {
+            dismissPassphraseDialog();
+            dismissBackoffDialog();
+            Toast.makeText(getMapView().getContext(), "Device locked — disconnecting", Toast.LENGTH_SHORT).show();
+            meshtasticBridge.disconnect();
+        }
+    }
+
+    private String formatLockdownStatus(LockdownState state, LockdownTokenInfo token) {
+        if (state instanceof LockdownState.None) return "Status: not locked";
+        if (state instanceof LockdownState.NeedsProvision) return "Status: needs passphrase setup";
+        if (state instanceof LockdownState.Locked) return "Status: locked";
+        if (state instanceof LockdownState.UnlockFailed) return "Status: wrong passphrase";
+        if (state instanceof LockdownState.UnlockBackoff) {
+            return "Status: rate-limited (" + ((LockdownState.UnlockBackoff) state).getBackoffSeconds() + "s)";
+        }
+        if (state instanceof LockdownState.Unlocked) {
+            if (token != null) {
+                String exp = token.getExpiryEpoch() > 0 ? (", until=" + token.getExpiryEpoch()) : "";
+                return "Status: unlocked (boots=" + token.getBootsRemaining() + exp + ")";
+            }
+            return "Status: unlocked";
+        }
+        if (state instanceof LockdownState.LockNowAcknowledged) return "Status: locking…";
+        return "Status: unknown";
+    }
+
+    private void showPassphraseDialog(boolean firstTime) {
+        if (passphraseDialog != null && passphraseDialog.isShowing()) return;
+        Context dlgCtx = getMapView().getContext();
+        LinearLayout container = new LinearLayout(dlgCtx);
+        container.setOrientation(LinearLayout.VERTICAL);
+        int pad = (int) (16 * dlgCtx.getResources().getDisplayMetrics().density);
+        container.setPadding(pad, pad, pad, pad);
+
+        if (firstTime) {
+            TextView hint = new TextView(dlgCtx);
+            hint.setText("First-time setup — pick a passphrase you can re-enter.");
+            container.addView(hint);
+        }
+
+        final EditText passField = new EditText(dlgCtx);
+        passField.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
+        passField.setHint("Passphrase (1–32 chars)");
+        container.addView(passField);
+
+        TextView bootsLabel = new TextView(dlgCtx);
+        bootsLabel.setText("Boots remaining (0 = firmware default)");
+        container.addView(bootsLabel);
+        final EditText bootsField = new EditText(dlgCtx);
+        bootsField.setInputType(InputType.TYPE_CLASS_NUMBER);
+        bootsField.setText("0");
+        container.addView(bootsField);
+
+        TextView hoursLabel = new TextView(dlgCtx);
+        hoursLabel.setText("Hours valid (0 = no time limit)");
+        container.addView(hoursLabel);
+        final EditText hoursField = new EditText(dlgCtx);
+        hoursField.setInputType(InputType.TYPE_CLASS_NUMBER);
+        hoursField.setText("0");
+        container.addView(hoursField);
+
+        AlertDialog.Builder b = new AlertDialog.Builder(dlgCtx);
+        b.setTitle(firstTime ? "Set device passphrase" : "Unlock device");
+        b.setView(container);
+        b.setPositiveButton(firstTime ? "Set" : "Unlock", (d, w) -> {
+            String pass = passField.getText().toString();
+            if (pass.isEmpty() || pass.length() > 32) {
+                Toast.makeText(dlgCtx, "Passphrase must be 1–32 bytes", Toast.LENGTH_SHORT).show();
+                return;
+            }
+            int boots = parseIntOrZero(bootsField.getText().toString());
+            int hours = parseIntOrZero(hoursField.getText().toString());
+            meshtasticBridge.submitLockdownPassphrase(pass, boots, hours);
+        });
+        b.setNegativeButton("Cancel", null);
+        b.setCancelable(false);
+        passphraseDialog = b.create();
+        passphraseDialog.show();
+    }
+
+    private void showBackoffDialog(int initialSeconds) {
+        dismissBackoffDialog();
+        Context dlgCtx = getMapView().getContext();
+        AlertDialog.Builder b = new AlertDialog.Builder(dlgCtx);
+        b.setTitle("Rate-limited");
+        b.setCancelable(false);
+        b.setNegativeButton("Cancel", null);
+        backoffDialog = b.create();
+        backoffDialog.setMessage("Too many attempts — retry in " + initialSeconds + "s");
+        backoffDialog.show();
+
+        final int[] remaining = { initialSeconds };
+        backoffTickRunnable = new Runnable() {
+            @Override public void run() {
+                remaining[0] -= 1;
+                if (remaining[0] <= 0) {
+                    dismissBackoffDialog();
+                    // Re-prompt for passphrase once the backoff has elapsed; the firmware will
+                    // tell us again via LOCKDOWN_LOCKED if it's still locked.
+                    if (currentLockdownState instanceof LockdownState.UnlockBackoff) {
+                        showPassphraseDialog(false);
+                    }
+                    return;
+                }
+                if (backoffDialog != null && backoffDialog.isShowing()) {
+                    backoffDialog.setMessage("Too many attempts — retry in " + remaining[0] + "s");
+                }
+                uiHandler.postDelayed(this, 1000);
+            }
+        };
+        uiHandler.postDelayed(backoffTickRunnable, 1000);
+    }
+
+    private void dismissPassphraseDialog() {
+        if (passphraseDialog != null && passphraseDialog.isShowing()) passphraseDialog.dismiss();
+        passphraseDialog = null;
+    }
+
+    private void dismissBackoffDialog() {
+        if (backoffTickRunnable != null) uiHandler.removeCallbacks(backoffTickRunnable);
+        backoffTickRunnable = null;
+        if (backoffDialog != null && backoffDialog.isShowing()) backoffDialog.dismiss();
+        backoffDialog = null;
+    }
+
+    private void confirmAndLockNow() {
+        Context dlgCtx = getMapView().getContext();
+        new AlertDialog.Builder(dlgCtx)
+                .setTitle("Lock device now?")
+                .setMessage("This revokes the current session and reboots the device locked. You will need the passphrase to reconnect.")
+                .setPositiveButton("Lock", (d, w) -> meshtasticBridge.lockNow())
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    private static int parseIntOrZero(String s) {
+        try { return Integer.parseInt(s.trim()); } catch (Exception e) { return 0; }
     }
 
     private void initializeUI() {
@@ -1088,6 +1275,11 @@ public class MeshtasticDropDownReceiver extends DropDownReceiver implements Drop
         if (bleScanner != null) {
             bleScanner.cleanup();
         }
+        if (meshtasticBridge != null) {
+            meshtasticBridge.setLockdownListener(null);
+        }
+        dismissPassphraseDialog();
+        dismissBackoffDialog();
     }
 
     @Override

--- a/app/src/main/java/com/atakmap/android/pluginmeshtastic/MeshtasticDropDownReceiver.java
+++ b/app/src/main/java/com/atakmap/android/pluginmeshtastic/MeshtasticDropDownReceiver.java
@@ -25,7 +25,6 @@ import com.atakmap.android.dropdown.DropDownReceiver;
 import com.atakmap.android.maps.MapView;
 import com.atakmap.android.pluginmeshtastic.meshtastic.AtakMeshtasticBridge;
 import com.atakmap.android.pluginmeshtastic.meshtastic.LockdownState;
-import com.atakmap.android.pluginmeshtastic.meshtastic.LockdownTokenInfo;
 import com.atakmap.android.pluginmeshtastic.meshtastic.MeshtasticBleScanner;
 import com.atakmap.android.pluginmeshtastic.meshtastic.MeshtasticManager;
 import android.text.InputType;
@@ -162,18 +161,20 @@ public class MeshtasticDropDownReceiver extends DropDownReceiver implements Drop
         if (lockNowButton != null) {
             lockNowButton.setOnClickListener(v -> confirmAndLockNow());
         }
-        meshtasticBridge.setLockdownListener((state, token) -> uiHandler.post(() -> onLockdownState(state, token)));
+        meshtasticBridge.setLockdownListener(state -> uiHandler.post(() -> onLockdownState(state)));
     }
 
-    private void onLockdownState(LockdownState state, LockdownTokenInfo token) {
+    private void onLockdownState(LockdownState state) {
         currentLockdownState = state;
         if (lockdownStatusText != null) {
-            lockdownStatusText.setText(formatLockdownStatus(state, token));
+            lockdownStatusText.setText(formatLockdownStatus(state));
         }
         if (state instanceof LockdownState.NeedsProvision) {
             dismissBackoffDialog();
             showPassphraseDialog(true);
         } else if (state instanceof LockdownState.Locked) {
+            // Locked with any reason — auto-replay happens in the coordinator before we get
+            // here, so reaching this state means we need to prompt.
             dismissBackoffDialog();
             showPassphraseDialog(false);
         } else if (state instanceof LockdownState.UnlockFailed) {
@@ -196,20 +197,21 @@ public class MeshtasticDropDownReceiver extends DropDownReceiver implements Drop
         }
     }
 
-    private String formatLockdownStatus(LockdownState state, LockdownTokenInfo token) {
+    private String formatLockdownStatus(LockdownState state) {
         if (state instanceof LockdownState.None) return "Status: not locked";
         if (state instanceof LockdownState.NeedsProvision) return "Status: needs passphrase setup";
-        if (state instanceof LockdownState.Locked) return "Status: locked";
+        if (state instanceof LockdownState.Locked) {
+            String reason = ((LockdownState.Locked) state).getReason();
+            return reason.isEmpty() ? "Status: locked" : ("Status: locked (" + reason + ")");
+        }
         if (state instanceof LockdownState.UnlockFailed) return "Status: wrong passphrase";
         if (state instanceof LockdownState.UnlockBackoff) {
             return "Status: rate-limited (" + ((LockdownState.UnlockBackoff) state).getBackoffSeconds() + "s)";
         }
         if (state instanceof LockdownState.Unlocked) {
-            if (token != null) {
-                String exp = token.getExpiryEpoch() > 0 ? (", until=" + token.getExpiryEpoch()) : "";
-                return "Status: unlocked (boots=" + token.getBootsRemaining() + exp + ")";
-            }
-            return "Status: unlocked";
+            LockdownState.Unlocked u = (LockdownState.Unlocked) state;
+            String exp = u.getValidUntilEpoch() > 0 ? (", until=" + u.getValidUntilEpoch()) : "";
+            return "Status: unlocked (boots=" + u.getBootsRemaining() + exp + ")";
         }
         if (state instanceof LockdownState.LockNowAcknowledged) return "Status: locking…";
         return "Status: unknown";
@@ -1340,6 +1342,18 @@ public class MeshtasticDropDownReceiver extends DropDownReceiver implements Drop
         });
     }
     
+    /**
+     * Called by the bridge whenever a Config response is parsed and cached. The
+     * Device-Information card reads from cached config; this push lets it re-render
+     * after a post-reboot reconnect without the user toggling Disconnect/Connect.
+     */
+    public void onConfigUpdated() {
+        uiHandler.post(() -> {
+            updateConnectionStatus();
+            updateDeviceInfoForced();
+        });
+    }
+
     /**
      * Called when device name is updated (e.g., when NodeInfo is received)
      * This refreshes the UI to show the updated device name

--- a/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/AtakMeshtasticBridge.kt
+++ b/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/AtakMeshtasticBridge.kt
@@ -167,6 +167,9 @@ class AtakMeshtasticBridge(
         // Create and initialize the manager
         meshtasticManager = MeshtasticManager(mapViewContext)
         meshtasticManager?.registerAtakMessageHandler(this)
+
+        // Attach any lockdown listener that was registered before the manager existed.
+        attachLockdownListener()
         
         // Set up callback to update device name when NodeInfo is received
         meshtasticManager?.setDeviceNameUpdateCallback { longName ->
@@ -425,6 +428,47 @@ class AtakMeshtasticBridge(
         autoConnectBluetooth = false
         autoConnectUsb = false
         meshtasticManager?.disconnect()
+    }
+
+    /** Lockdown coordinator surface for the UI (state flow + actions). */
+    fun getLockdownCoordinator(): LockdownCoordinator? = meshtasticManager?.lockdownCoordinator
+
+    fun submitLockdownPassphrase(passphrase: String, boots: Int, hours: Int) {
+        meshtasticManager?.lockdownCoordinator?.submitPassphrase(passphrase, boots, hours)
+    }
+
+    fun lockNow() {
+        meshtasticManager?.lockdownCoordinator?.lockNow()
+    }
+
+    /** Java-friendly listener to react to lockdown state changes (delivered on the main thread). */
+    interface LockdownListener {
+        fun onLockdownState(state: LockdownState, tokenInfo: LockdownTokenInfo?)
+    }
+
+    private var lockdownListenerJob: Job? = null
+    private var pendingLockdownListener: LockdownListener? = null
+
+    fun setLockdownListener(listener: LockdownListener?) {
+        pendingLockdownListener = listener
+        attachLockdownListener()
+    }
+
+    private fun attachLockdownListener() {
+        lockdownListenerJob?.cancel()
+        lockdownListenerJob = null
+        val listener = pendingLockdownListener ?: return
+        val coord = meshtasticManager?.lockdownCoordinator ?: return // will retry after init
+        lockdownListenerJob = scope.launch {
+            kotlinx.coroutines.flow.combine(coord.state, coord.tokenInfo) { s, t -> s to t }
+                .collect { (state, token) ->
+                    try {
+                        listener.onLockdownState(state, token)
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Lockdown listener threw", e)
+                    }
+                }
+        }
     }
     
     /**

--- a/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/AtakMeshtasticBridge.kt
+++ b/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/AtakMeshtasticBridge.kt
@@ -176,6 +176,11 @@ class AtakMeshtasticBridge(
             Log.i(TAG, "NodeInfo callback triggered with longName: '$longName'")
             updateStoredDeviceName(longName)
         }
+
+        // Poke the UI whenever a Config response is cached (region, role, etc.).
+        meshtasticManager?.setConfigUpdateCallback {
+            notifyConfigUpdated()
+        }
         
         // Auto-connect if configured
         if (autoConnectBluetooth && bluetoothAddress != null) {
@@ -232,6 +237,20 @@ class AtakMeshtasticBridge(
         }
     }
     
+    /** Notify the DropDownReceiver that fresh Config data was cached. */
+    private fun notifyConfigUpdated() {
+        dropDownReceiver?.let { receiver ->
+            try {
+                val method = receiver::class.java.getMethod("onConfigUpdated")
+                method.invoke(receiver)
+            } catch (_: NoSuchMethodException) {
+                // Receiver doesn't care — silently skip.
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to notify DropDownReceiver of config update", e)
+            }
+        }
+    }
+
     /**
      * Notify the DropDownReceiver that the device name has been updated
      */
@@ -441,9 +460,9 @@ class AtakMeshtasticBridge(
         meshtasticManager?.lockdownCoordinator?.lockNow()
     }
 
-    /** Java-friendly listener to react to lockdown state changes (delivered on the main thread). */
+    /** Java-friendly listener for lockdown state changes (delivered on the main thread). */
     interface LockdownListener {
-        fun onLockdownState(state: LockdownState, tokenInfo: LockdownTokenInfo?)
+        fun onLockdownState(state: LockdownState)
     }
 
     private var lockdownListenerJob: Job? = null
@@ -460,14 +479,13 @@ class AtakMeshtasticBridge(
         val listener = pendingLockdownListener ?: return
         val coord = meshtasticManager?.lockdownCoordinator ?: return // will retry after init
         lockdownListenerJob = scope.launch {
-            kotlinx.coroutines.flow.combine(coord.state, coord.tokenInfo) { s, t -> s to t }
-                .collect { (state, token) ->
-                    try {
-                        listener.onLockdownState(state, token)
-                    } catch (e: Exception) {
-                        Log.w(TAG, "Lockdown listener threw", e)
-                    }
+            coord.state.collect { state ->
+                try {
+                    listener.onLockdownState(state)
+                } catch (e: Exception) {
+                    Log.w(TAG, "Lockdown listener threw", e)
                 }
+            }
         }
     }
     

--- a/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/BluetoothInterface.kt
+++ b/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/BluetoothInterface.kt
@@ -28,7 +28,7 @@ interface RadioCallback {
 
 class BluetoothInterface(
     private val context: Context,
-    private val deviceAddress: String,
+    val deviceAddress: String,
     private val callback: RadioCallback
 ) {
     companion object {

--- a/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/LockdownCoordinator.kt
+++ b/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/LockdownCoordinator.kt
@@ -2,27 +2,33 @@ package com.atakmap.android.pluginmeshtastic.meshtastic
 
 import android.content.Context
 import android.util.Log
+import com.geeksville.mesh.MeshProtos as GeneratedMeshProtos
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 /**
- * Hook used by [LockdownCoordinator] to send lockdown AdminMessage packets without dragging
- * the whole [MeshtasticManager] into the unit-test surface.
+ * Hook used by [LockdownCoordinator] to emit AdminMessage.lockdown_auth packets without
+ * dragging the entire [MeshtasticManager] into the unit-test surface.
  */
 interface LockdownSender {
+    /** Send AdminMessage.lockdown_auth with passphrase + boots/hours; lock_now=false. */
     fun sendLockdownPassphrase(passphrase: String, boots: Int, hours: Int)
+
+    /** Send AdminMessage.lockdown_auth with lock_now=true, empty passphrase. */
     fun sendLockNow()
-    /** Returns the BLE MAC (or USB path) of the currently-connected device, or null. */
+
+    /** BLE MAC (or USB path) of the currently-connected device, or null. */
     fun getDeviceAddress(): String?
 }
 
 /**
- * Coordinates the lockdown handshake — drives a [LockdownState] flow that the UI subscribes
- * to, auto-replays the cached passphrase silently, and only surfaces a dialog when no cached
- * passphrase exists or auto-unlock fails.
+ * Drives the lockdown handshake: handles inbound LockdownStatus events, auto-replays
+ * the cached passphrase silently, surfaces a dialog only when no cached passphrase
+ * exists or auto-unlock fails, and synthesizes [LockdownState.LockNowAcknowledged]
+ * for the firmware's Lock-Now reboot (which may race the BLE disconnect).
  *
- * State is per-BLE-connection: [onConnect] resets the "this connection is authorized" flag
- * (the firmware requires re-auth on every new connection, even if storage is already unlocked).
+ * State is per-BLE-connection: [onConnect] resets the "this connection is authorized"
+ * flag (firmware requires re-auth on every new connection even if storage is unlocked).
  */
 class LockdownCoordinator(
     context: Context,
@@ -33,9 +39,6 @@ class LockdownCoordinator(
     private val _state = MutableStateFlow<LockdownState>(LockdownState.None)
     val state: StateFlow<LockdownState> = _state
 
-    private val _tokenInfo = MutableStateFlow<LockdownTokenInfo?>(null)
-    val tokenInfo: StateFlow<LockdownTokenInfo?> = _tokenInfo
-
     private val _sessionAuthorized = MutableStateFlow(false)
     val sessionAuthorized: StateFlow<Boolean> = _sessionAuthorized
 
@@ -44,61 +47,73 @@ class LockdownCoordinator(
     @Volatile private var pendingBoots: Int = LockdownPassphraseStore.DEFAULT_BOOTS
     @Volatile private var pendingHours: Int = 0
 
-    /** Call when a fresh BLE/USB connection comes up. */
+    /**
+     * Set when the operator has requested Lock Now and we are waiting for the firmware's
+     * acknowledging LOCKED status. The next inbound LOCKED resolves it as
+     * [LockdownState.LockNowAcknowledged]; if the BLE drops first, [onDisconnect] also
+     * resolves it.
+     */
+    @Volatile private var pendingLockNow = false
+
     fun onConnect() {
         _sessionAuthorized.value = false
         wasAutoAttempt = false
         pendingPassphrase = null
         pendingBoots = LockdownPassphraseStore.DEFAULT_BOOTS
         pendingHours = 0
-        // Don't preemptively switch to Locked — wait for the device to tell us.
+        pendingLockNow = false
         _state.value = LockdownState.None
-        _tokenInfo.value = null
     }
 
-    /** Call when the BLE/USB connection drops. */
     fun onDisconnect() {
+        // If a Lock Now was in flight and the BLE dropped before the status arrived,
+        // treat the disconnect itself as the ack so the UI moves on.
+        if (pendingLockNow) {
+            pendingLockNow = false
+            _state.value = LockdownState.LockNowAcknowledged
+        } else {
+            _state.value = LockdownState.None
+        }
         _sessionAuthorized.value = false
         wasAutoAttempt = false
         pendingPassphrase = null
-        _tokenInfo.value = null
-        _state.value = LockdownState.None
     }
 
     /**
-     * Route an incoming ClientNotification message that starts with `LOCKDOWN_`.
-     * Caller is responsible for checking the prefix.
+     * Route an inbound typed LockdownStatus. Caller has already verified
+     * `FromRadio.payload_variant == lockdown_status`.
      */
-    fun handleLockdownNotification(message: String?) {
-        if (message == null) return
-        Log.i(TAG, "Lockdown notification: $message")
-        when {
-            message == LOCKDOWN_NEEDS_PROVISION -> _state.value = LockdownState.NeedsProvision
-            message == LOCKDOWN_LOCKED_ACK -> handleLockNowAcknowledged()
-            message.startsWith(LOCKDOWN_LOCKED_WITH_REASON_PREFIX) -> handleLocked()
-            message.startsWith(LOCKDOWN_UNLOCKED_PREFIX) -> handleUnlocked(message)
-            message.startsWith(LOCKDOWN_UNLOCK_FAILED_PREFIX) -> handleUnlockFailed(message)
-            else -> {
-                Log.w(TAG, "Unrecognized LOCKDOWN_ notification; treating as Locked")
-                _state.value = LockdownState.Locked
+    fun handleLockdownStatus(status: GeneratedMeshProtos.LockdownStatus) {
+        Log.i(TAG, "LockdownStatus: state=${status.state} reason='${status.lockReason}' " +
+                "boots=${status.bootsRemaining} until=${status.validUntilEpoch} " +
+                "backoff=${status.backoffSeconds}")
+        when (status.state) {
+            GeneratedMeshProtos.LockdownStatus.State.NEEDS_PROVISION -> {
+                _state.value = LockdownState.NeedsProvision
+            }
+            GeneratedMeshProtos.LockdownStatus.State.LOCKED -> handleLocked(status.lockReason ?: "")
+            GeneratedMeshProtos.LockdownStatus.State.UNLOCKED -> handleUnlocked(status)
+            GeneratedMeshProtos.LockdownStatus.State.UNLOCK_FAILED -> handleUnlockFailed(status.backoffSeconds)
+            GeneratedMeshProtos.LockdownStatus.State.STATE_UNSPECIFIED,
+            GeneratedMeshProtos.LockdownStatus.State.UNRECOGNIZED -> {
+                Log.w(TAG, "Ignoring LockdownStatus with unspecified/unknown state")
             }
         }
     }
 
-    private fun handleLockNowAcknowledged() {
-        Log.i(TAG, "Lock Now acknowledged — clearing session authorization")
-        _sessionAuthorized.value = false
-        wasAutoAttempt = false
-        pendingPassphrase = null
-        _state.value = LockdownState.LockNowAcknowledged
-    }
-
-    private fun handleLocked() {
+    private fun handleLocked(reason: String) {
+        // Firmware emits a LOCKED status as the Lock-Now ack right before reboot.
+        if (pendingLockNow) {
+            pendingLockNow = false
+            _sessionAuthorized.value = false
+            _state.value = LockdownState.LockNowAcknowledged
+            return
+        }
         val address = sender.getDeviceAddress()
         if (address != null) {
             val stored = passphraseStore.getPassphrase(address)
             if (stored != null) {
-                Log.i(TAG, "Auto-replaying cached passphrase for $address")
+                Log.i(TAG, "Auto-replaying cached passphrase for $address (reason=$reason)")
                 wasAutoAttempt = true
                 pendingPassphrase = stored.passphrase
                 pendingBoots = stored.boots
@@ -107,10 +122,10 @@ class LockdownCoordinator(
                 return
             }
         }
-        _state.value = LockdownState.Locked
+        _state.value = LockdownState.Locked(reason)
     }
 
-    private fun handleUnlocked(message: String) {
+    private fun handleUnlocked(status: GeneratedMeshProtos.LockdownStatus) {
         val address = sender.getDeviceAddress()
         val passphrase = pendingPassphrase
         if (address != null && passphrase != null) {
@@ -119,49 +134,37 @@ class LockdownCoordinator(
         }
         pendingPassphrase = null
         wasAutoAttempt = false
-        _tokenInfo.value = parseTokenInfo(message)
         _sessionAuthorized.value = true
-        _state.value = LockdownState.Unlocked
+        _state.value = LockdownState.Unlocked(
+            bootsRemaining = status.bootsRemaining,
+            validUntilEpoch = status.validUntilEpoch.toLong() and 0xFFFFFFFFL,
+        )
     }
 
-    private fun handleUnlockFailed(message: String) {
-        val backoffSeconds = message.split(":").firstNotNullOfOrNull { seg ->
-            if (seg.startsWith("backoff=")) seg.removePrefix("backoff=").toIntOrNull() else null
-        }
+    private fun handleUnlockFailed(backoffSeconds: Int) {
         val wasAuto = wasAutoAttempt
         wasAutoAttempt = false
         pendingPassphrase = null
         if (wasAuto) {
-            if (backoffSeconds != null && backoffSeconds > 0) {
+            if (backoffSeconds > 0) {
                 Log.i(TAG, "Auto-unlock rate-limited (backoff=${backoffSeconds}s)")
                 _state.value = LockdownState.UnlockBackoff(backoffSeconds)
             } else {
+                // Assume the cached passphrase was rotated server-side.
                 sender.getDeviceAddress()?.let { passphraseStore.clearPassphrase(it) }
-                Log.i(TAG, "Auto-unlock failed (wrong passphrase), cleared cached passphrase")
-                _state.value = LockdownState.Locked
+                Log.i(TAG, "Auto-unlock failed (wrong passphrase); cleared cached passphrase")
+                _state.value = LockdownState.Locked("auto_replay_wrong_passphrase")
             }
             return
         }
-        if (backoffSeconds != null && backoffSeconds > 0) {
-            _state.value = LockdownState.UnlockBackoff(backoffSeconds)
+        _state.value = if (backoffSeconds > 0) {
+            LockdownState.UnlockBackoff(backoffSeconds)
         } else {
-            _state.value = LockdownState.UnlockFailed
+            LockdownState.UnlockFailed
         }
     }
 
-    private fun parseTokenInfo(message: String): LockdownTokenInfo? {
-        var boots = -1
-        var until = 0L
-        for (segment in message.split(":")) {
-            when {
-                segment.startsWith("boots=") -> boots = segment.removePrefix("boots=").toIntOrNull() ?: -1
-                segment.startsWith("until=") -> until = segment.removePrefix("until=").toLongOrNull() ?: 0L
-            }
-        }
-        return if (boots >= 0) LockdownTokenInfo(boots, until) else null
-    }
-
-    /** User-initiated passphrase submission. */
+    /** User-initiated passphrase submission (provision or unlock). */
     fun submitPassphrase(passphrase: String, boots: Int, hours: Int) {
         pendingPassphrase = passphrase
         pendingBoots = boots
@@ -173,26 +176,16 @@ class LockdownCoordinator(
 
     /** User-initiated Lock Now. */
     fun lockNow() {
+        pendingLockNow = true
         sender.sendLockNow()
     }
 
-    /** Forget the cached passphrase for the current (or given) device. */
+    /** Drop any cached passphrase for the current device. */
     fun forgetCachedPassphrase(address: String? = sender.getDeviceAddress()) {
         address?.let { passphraseStore.clearPassphrase(it) }
     }
 
     companion object {
         private const val TAG = "LockdownCoordinator"
-
-        // Wire-format string prefixes from firmware PR #10349. The firmware-side migration to
-        // structured LockdownStatus (protobufs PR #911) is a follow-up; when that lands we can
-        // add a second observer path here that consumes LockdownStatus and feeds the same state.
-        private const val LOCKDOWN_NEEDS_PROVISION = "LOCKDOWN_NEEDS_PROVISION"
-        private const val LOCKDOWN_LOCKED_ACK = "LOCKDOWN_LOCKED" // exact match: Lock Now ACK
-        private const val LOCKDOWN_LOCKED_WITH_REASON_PREFIX = "LOCKDOWN_LOCKED:"
-        private const val LOCKDOWN_UNLOCKED_PREFIX = "LOCKDOWN_UNLOCKED"
-        private const val LOCKDOWN_UNLOCK_FAILED_PREFIX = "LOCKDOWN_UNLOCK_FAILED"
-
-        const val PREFIX = "LOCKDOWN_"
     }
 }

--- a/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/LockdownCoordinator.kt
+++ b/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/LockdownCoordinator.kt
@@ -1,0 +1,198 @@
+package com.atakmap.android.pluginmeshtastic.meshtastic
+
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Hook used by [LockdownCoordinator] to send lockdown AdminMessage packets without dragging
+ * the whole [MeshtasticManager] into the unit-test surface.
+ */
+interface LockdownSender {
+    fun sendLockdownPassphrase(passphrase: String, boots: Int, hours: Int)
+    fun sendLockNow()
+    /** Returns the BLE MAC (or USB path) of the currently-connected device, or null. */
+    fun getDeviceAddress(): String?
+}
+
+/**
+ * Coordinates the lockdown handshake — drives a [LockdownState] flow that the UI subscribes
+ * to, auto-replays the cached passphrase silently, and only surfaces a dialog when no cached
+ * passphrase exists or auto-unlock fails.
+ *
+ * State is per-BLE-connection: [onConnect] resets the "this connection is authorized" flag
+ * (the firmware requires re-auth on every new connection, even if storage is already unlocked).
+ */
+class LockdownCoordinator(
+    context: Context,
+    private val sender: LockdownSender,
+) {
+    private val passphraseStore = LockdownPassphraseStore(context)
+
+    private val _state = MutableStateFlow<LockdownState>(LockdownState.None)
+    val state: StateFlow<LockdownState> = _state
+
+    private val _tokenInfo = MutableStateFlow<LockdownTokenInfo?>(null)
+    val tokenInfo: StateFlow<LockdownTokenInfo?> = _tokenInfo
+
+    private val _sessionAuthorized = MutableStateFlow(false)
+    val sessionAuthorized: StateFlow<Boolean> = _sessionAuthorized
+
+    @Volatile private var wasAutoAttempt = false
+    @Volatile private var pendingPassphrase: String? = null
+    @Volatile private var pendingBoots: Int = LockdownPassphraseStore.DEFAULT_BOOTS
+    @Volatile private var pendingHours: Int = 0
+
+    /** Call when a fresh BLE/USB connection comes up. */
+    fun onConnect() {
+        _sessionAuthorized.value = false
+        wasAutoAttempt = false
+        pendingPassphrase = null
+        pendingBoots = LockdownPassphraseStore.DEFAULT_BOOTS
+        pendingHours = 0
+        // Don't preemptively switch to Locked — wait for the device to tell us.
+        _state.value = LockdownState.None
+        _tokenInfo.value = null
+    }
+
+    /** Call when the BLE/USB connection drops. */
+    fun onDisconnect() {
+        _sessionAuthorized.value = false
+        wasAutoAttempt = false
+        pendingPassphrase = null
+        _tokenInfo.value = null
+        _state.value = LockdownState.None
+    }
+
+    /**
+     * Route an incoming ClientNotification message that starts with `LOCKDOWN_`.
+     * Caller is responsible for checking the prefix.
+     */
+    fun handleLockdownNotification(message: String?) {
+        if (message == null) return
+        Log.i(TAG, "Lockdown notification: $message")
+        when {
+            message == LOCKDOWN_NEEDS_PROVISION -> _state.value = LockdownState.NeedsProvision
+            message == LOCKDOWN_LOCKED_ACK -> handleLockNowAcknowledged()
+            message.startsWith(LOCKDOWN_LOCKED_WITH_REASON_PREFIX) -> handleLocked()
+            message.startsWith(LOCKDOWN_UNLOCKED_PREFIX) -> handleUnlocked(message)
+            message.startsWith(LOCKDOWN_UNLOCK_FAILED_PREFIX) -> handleUnlockFailed(message)
+            else -> {
+                Log.w(TAG, "Unrecognized LOCKDOWN_ notification; treating as Locked")
+                _state.value = LockdownState.Locked
+            }
+        }
+    }
+
+    private fun handleLockNowAcknowledged() {
+        Log.i(TAG, "Lock Now acknowledged — clearing session authorization")
+        _sessionAuthorized.value = false
+        wasAutoAttempt = false
+        pendingPassphrase = null
+        _state.value = LockdownState.LockNowAcknowledged
+    }
+
+    private fun handleLocked() {
+        val address = sender.getDeviceAddress()
+        if (address != null) {
+            val stored = passphraseStore.getPassphrase(address)
+            if (stored != null) {
+                Log.i(TAG, "Auto-replaying cached passphrase for $address")
+                wasAutoAttempt = true
+                pendingPassphrase = stored.passphrase
+                pendingBoots = stored.boots
+                pendingHours = stored.hours
+                sender.sendLockdownPassphrase(stored.passphrase, stored.boots, stored.hours)
+                return
+            }
+        }
+        _state.value = LockdownState.Locked
+    }
+
+    private fun handleUnlocked(message: String) {
+        val address = sender.getDeviceAddress()
+        val passphrase = pendingPassphrase
+        if (address != null && passphrase != null) {
+            passphraseStore.savePassphrase(address, passphrase, pendingBoots, pendingHours)
+            Log.i(TAG, "Saved passphrase for $address")
+        }
+        pendingPassphrase = null
+        wasAutoAttempt = false
+        _tokenInfo.value = parseTokenInfo(message)
+        _sessionAuthorized.value = true
+        _state.value = LockdownState.Unlocked
+    }
+
+    private fun handleUnlockFailed(message: String) {
+        val backoffSeconds = message.split(":").firstNotNullOfOrNull { seg ->
+            if (seg.startsWith("backoff=")) seg.removePrefix("backoff=").toIntOrNull() else null
+        }
+        val wasAuto = wasAutoAttempt
+        wasAutoAttempt = false
+        pendingPassphrase = null
+        if (wasAuto) {
+            if (backoffSeconds != null && backoffSeconds > 0) {
+                Log.i(TAG, "Auto-unlock rate-limited (backoff=${backoffSeconds}s)")
+                _state.value = LockdownState.UnlockBackoff(backoffSeconds)
+            } else {
+                sender.getDeviceAddress()?.let { passphraseStore.clearPassphrase(it) }
+                Log.i(TAG, "Auto-unlock failed (wrong passphrase), cleared cached passphrase")
+                _state.value = LockdownState.Locked
+            }
+            return
+        }
+        if (backoffSeconds != null && backoffSeconds > 0) {
+            _state.value = LockdownState.UnlockBackoff(backoffSeconds)
+        } else {
+            _state.value = LockdownState.UnlockFailed
+        }
+    }
+
+    private fun parseTokenInfo(message: String): LockdownTokenInfo? {
+        var boots = -1
+        var until = 0L
+        for (segment in message.split(":")) {
+            when {
+                segment.startsWith("boots=") -> boots = segment.removePrefix("boots=").toIntOrNull() ?: -1
+                segment.startsWith("until=") -> until = segment.removePrefix("until=").toLongOrNull() ?: 0L
+            }
+        }
+        return if (boots >= 0) LockdownTokenInfo(boots, until) else null
+    }
+
+    /** User-initiated passphrase submission. */
+    fun submitPassphrase(passphrase: String, boots: Int, hours: Int) {
+        pendingPassphrase = passphrase
+        pendingBoots = boots
+        pendingHours = hours
+        wasAutoAttempt = false
+        _state.value = LockdownState.None // hide dialog while we wait for the response
+        sender.sendLockdownPassphrase(passphrase, boots, hours)
+    }
+
+    /** User-initiated Lock Now. */
+    fun lockNow() {
+        sender.sendLockNow()
+    }
+
+    /** Forget the cached passphrase for the current (or given) device. */
+    fun forgetCachedPassphrase(address: String? = sender.getDeviceAddress()) {
+        address?.let { passphraseStore.clearPassphrase(it) }
+    }
+
+    companion object {
+        private const val TAG = "LockdownCoordinator"
+
+        // Wire-format string prefixes from firmware PR #10349. The firmware-side migration to
+        // structured LockdownStatus (protobufs PR #911) is a follow-up; when that lands we can
+        // add a second observer path here that consumes LockdownStatus and feeds the same state.
+        private const val LOCKDOWN_NEEDS_PROVISION = "LOCKDOWN_NEEDS_PROVISION"
+        private const val LOCKDOWN_LOCKED_ACK = "LOCKDOWN_LOCKED" // exact match: Lock Now ACK
+        private const val LOCKDOWN_LOCKED_WITH_REASON_PREFIX = "LOCKDOWN_LOCKED:"
+        private const val LOCKDOWN_UNLOCKED_PREFIX = "LOCKDOWN_UNLOCKED"
+        private const val LOCKDOWN_UNLOCK_FAILED_PREFIX = "LOCKDOWN_UNLOCK_FAILED"
+
+        const val PREFIX = "LOCKDOWN_"
+    }
+}

--- a/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/LockdownPassphraseStore.kt
+++ b/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/LockdownPassphraseStore.kt
@@ -1,0 +1,87 @@
+package com.atakmap.android.pluginmeshtastic.meshtastic
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+data class StoredPassphrase(
+    val passphrase: String,
+    val boots: Int,
+    val hours: Int,
+)
+
+/**
+ * Per-device encrypted storage for lockdown passphrases.
+ *
+ * Backed by EncryptedSharedPreferences with an AES-256-GCM master key from the Android
+ * Keystore. The key is intentionally not biometric-gated so silent auto-unlock can run
+ * after a reconnect without user interaction.
+ *
+ * Keyed by BLE MAC address (or USB device path) so a plugin instance connecting to a
+ * second device does not inherit the first device's cached passphrase.
+ */
+class LockdownPassphraseStore(context: Context) {
+
+    private val prefs: SharedPreferences by lazy {
+        val masterKey = MasterKey.Builder(context.applicationContext)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        try {
+            EncryptedSharedPreferences.create(
+                context.applicationContext,
+                PREFS_FILE_NAME,
+                masterKey,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+            )
+        } catch (e: Exception) {
+            // EncryptedSharedPreferences can fail if the underlying keyset file is corrupted
+            // (e.g. after a backup/restore). Wipe and recreate rather than crash the plugin.
+            Log.w(TAG, "Failed to open EncryptedSharedPreferences, wiping and retrying", e)
+            context.applicationContext.deleteSharedPreferences(PREFS_FILE_NAME)
+            EncryptedSharedPreferences.create(
+                context.applicationContext,
+                PREFS_FILE_NAME,
+                masterKey,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+            )
+        }
+    }
+
+    fun getPassphrase(deviceAddress: String): StoredPassphrase? {
+        val key = sanitizeKey(deviceAddress)
+        val passphrase = prefs.getString("${key}_passphrase", null) ?: return null
+        val boots = prefs.getInt("${key}_boots", DEFAULT_BOOTS)
+        val hours = prefs.getInt("${key}_hours", 0)
+        return StoredPassphrase(passphrase, boots, hours)
+    }
+
+    fun savePassphrase(deviceAddress: String, passphrase: String, boots: Int, hours: Int) {
+        val key = sanitizeKey(deviceAddress)
+        prefs.edit()
+            .putString("${key}_passphrase", passphrase)
+            .putInt("${key}_boots", boots)
+            .putInt("${key}_hours", hours)
+            .apply()
+    }
+
+    fun clearPassphrase(deviceAddress: String) {
+        val key = sanitizeKey(deviceAddress)
+        prefs.edit()
+            .remove("${key}_passphrase")
+            .remove("${key}_boots")
+            .remove("${key}_hours")
+            .apply()
+    }
+
+    private fun sanitizeKey(address: String): String = address.replace(":", "_").replace('/', '_')
+
+    companion object {
+        private const val TAG = "LockdownPassphraseStore"
+        private const val PREFS_FILE_NAME = "lockdown_passphrase_store"
+        const val DEFAULT_BOOTS = 50
+    }
+}

--- a/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/LockdownState.kt
+++ b/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/LockdownState.kt
@@ -1,0 +1,41 @@
+package com.atakmap.android.pluginmeshtastic.meshtastic
+
+/**
+ * Represents the lockdown authentication state for a hardened Meshtastic device.
+ *
+ * Mirrors the public surface from the Meshtastic-Android reference implementation
+ * (org.meshtastic.core.model.service.LockdownState) so the UI can drive the same flows.
+ */
+sealed class LockdownState {
+    /** No lockdown signal received (default for non-hardened devices). */
+    object None : LockdownState()
+
+    /** Device is locked and this connection has not been authorized yet. */
+    object Locked : LockdownState()
+
+    /** First-boot device with no passphrase set yet — prompt user to pick one. */
+    object NeedsProvision : LockdownState()
+
+    /** Session is authorized; optional token metadata in [LockdownCoordinator.tokenInfo]. */
+    object Unlocked : LockdownState()
+
+    /** Lock Now ACK received — caller should drop the BLE connection. */
+    object LockNowAcknowledged : LockdownState()
+
+    /** Wrong passphrase — retry immediately. */
+    object UnlockFailed : LockdownState()
+
+    /** Too many failed attempts — caller must wait [backoffSeconds] before retrying. */
+    data class UnlockBackoff(val backoffSeconds: Int) : LockdownState()
+}
+
+/**
+ * Parsed metadata from a LOCKDOWN_UNLOCKED:boots=N:until=EPOCH notification.
+ *
+ * @param bootsRemaining reboots before the token expires.
+ * @param expiryEpoch unix epoch seconds; 0 = no wall-clock expiry.
+ */
+data class LockdownTokenInfo(
+    val bootsRemaining: Int,
+    val expiryEpoch: Long,
+)

--- a/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/LockdownState.kt
+++ b/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/LockdownState.kt
@@ -1,41 +1,40 @@
 package com.atakmap.android.pluginmeshtastic.meshtastic
 
 /**
- * Represents the lockdown authentication state for a hardened Meshtastic device.
+ * Lockdown authentication state for a MESHTASTIC_LOCKDOWN-hardened device.
  *
- * Mirrors the public surface from the Meshtastic-Android reference implementation
- * (org.meshtastic.core.model.service.LockdownState) so the UI can drive the same flows.
+ * Driven by FromRadio.lockdown_status (typed proto wire format from
+ * meshtastic/protobufs PR #911). The UI subscribes to a flow of these.
  */
 sealed class LockdownState {
-    /** No lockdown signal received (default for non-hardened devices). */
+    /** No lockdown signal received yet (default for non-hardened firmware). */
     object None : LockdownState()
 
-    /** Device is locked and this connection has not been authorized yet. */
-    object Locked : LockdownState()
-
-    /** First-boot device with no passphrase set yet — prompt user to pick one. */
+    /** First-boot device with no passphrase set — prompt operator to pick one. */
     object NeedsProvision : LockdownState()
 
-    /** Session is authorized; optional token metadata in [LockdownCoordinator.tokenInfo]. */
-    object Unlocked : LockdownState()
+    /**
+     * Storage is locked or this connection hasn't authed yet.
+     * [reason] is the firmware-supplied `lock_reason` string (machine-readable);
+     * unknown reasons are still treated as Locked.
+     */
+    data class Locked(val reason: String) : LockdownState()
 
-    /** Lock Now ACK received — caller should drop the BLE connection. */
-    object LockNowAcknowledged : LockdownState()
+    /**
+     * Session authorized. [bootsRemaining] and [validUntilEpoch] mirror the firmware's
+     * session token TTL (epoch=0 means no wall-clock expiry).
+     */
+    data class Unlocked(val bootsRemaining: Int, val validUntilEpoch: Long) : LockdownState()
 
-    /** Wrong passphrase — retry immediately. */
+    /** Wrong passphrase, no rate-limit — retry allowed immediately. */
     object UnlockFailed : LockdownState()
 
-    /** Too many failed attempts — caller must wait [backoffSeconds] before retrying. */
+    /** Rate-limited — caller must wait [backoffSeconds] before retrying. */
     data class UnlockBackoff(val backoffSeconds: Int) : LockdownState()
-}
 
-/**
- * Parsed metadata from a LOCKDOWN_UNLOCKED:boots=N:until=EPOCH notification.
- *
- * @param bootsRemaining reboots before the token expires.
- * @param expiryEpoch unix epoch seconds; 0 = no wall-clock expiry.
- */
-data class LockdownTokenInfo(
-    val bootsRemaining: Int,
-    val expiryEpoch: Long,
-)
+    /**
+     * Synthetic state — set when the coordinator's pending Lock Now flag is resolved
+     * by the next inbound LOCKED status (or a connection drop). UI should disconnect.
+     */
+    object LockNowAcknowledged : LockdownState()
+}

--- a/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/MeshProtos.kt
+++ b/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/MeshProtos.kt
@@ -175,6 +175,17 @@ object MeshProtos {
     )
     
     /**
+     * Lightweight wrapper around the ClientNotification proto. Carries only the fields the
+     * plugin actually inspects (the lockdown dispatcher just needs `message`).
+     */
+    data class ClientNotificationData(
+        val message: String,
+        val replyId: Int = 0,
+        val time: Int = 0,
+        val level: Int = 0,
+    )
+
+    /**
      * Message received from radio
      */
     data class FromRadio(
@@ -189,7 +200,8 @@ object MeshProtos {
         val metadata: com.geeksville.mesh.MeshProtos.DeviceMetadata? = null,
         val config: com.geeksville.mesh.ConfigProtos.Config? = null,
         val moduleConfig: com.geeksville.mesh.ModuleConfigProtos.ModuleConfig? = null,
-        val channel: com.geeksville.mesh.ChannelProtos.Channel? = null
+        val channel: com.geeksville.mesh.ChannelProtos.Channel? = null,
+        val clientNotification: ClientNotificationData? = null
     ) {
         companion object {
             fun parseFrom(data: ByteArray): FromRadio? {
@@ -329,7 +341,19 @@ object MeshProtos {
                         protoFromRadio.hasChannel() -> {
                             FromRadio(channel = protoFromRadio.channel)
                         }
-                        
+
+                        protoFromRadio.hasClientNotification() -> {
+                            val cn = protoFromRadio.clientNotification
+                            FromRadio(
+                                clientNotification = ClientNotificationData(
+                                    message = cn.message ?: "",
+                                    replyId = cn.replyId,
+                                    time = cn.time,
+                                    level = cn.levelValue
+                                )
+                            )
+                        }
+
                         else -> {
                             // Unknown or unhandled message type
                             null

--- a/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/MeshProtos.kt
+++ b/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/MeshProtos.kt
@@ -175,17 +175,6 @@ object MeshProtos {
     )
     
     /**
-     * Lightweight wrapper around the ClientNotification proto. Carries only the fields the
-     * plugin actually inspects (the lockdown dispatcher just needs `message`).
-     */
-    data class ClientNotificationData(
-        val message: String,
-        val replyId: Int = 0,
-        val time: Int = 0,
-        val level: Int = 0,
-    )
-
-    /**
      * Message received from radio
      */
     data class FromRadio(
@@ -201,7 +190,7 @@ object MeshProtos {
         val config: com.geeksville.mesh.ConfigProtos.Config? = null,
         val moduleConfig: com.geeksville.mesh.ModuleConfigProtos.ModuleConfig? = null,
         val channel: com.geeksville.mesh.ChannelProtos.Channel? = null,
-        val clientNotification: ClientNotificationData? = null
+        val lockdownStatus: com.geeksville.mesh.MeshProtos.LockdownStatus? = null
     ) {
         companion object {
             fun parseFrom(data: ByteArray): FromRadio? {
@@ -342,16 +331,8 @@ object MeshProtos {
                             FromRadio(channel = protoFromRadio.channel)
                         }
 
-                        protoFromRadio.hasClientNotification() -> {
-                            val cn = protoFromRadio.clientNotification
-                            FromRadio(
-                                clientNotification = ClientNotificationData(
-                                    message = cn.message ?: "",
-                                    replyId = cn.replyId,
-                                    time = cn.time,
-                                    level = cn.levelValue
-                                )
-                            )
+                        protoFromRadio.hasLockdownStatus() -> {
+                            FromRadio(lockdownStatus = protoFromRadio.lockdownStatus)
                         }
 
                         else -> {

--- a/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/MeshtasticConfigManager.kt
+++ b/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/MeshtasticConfigManager.kt
@@ -689,7 +689,7 @@ class MeshtasticConfigManager(
                 val lora = config.lora
                 if (!lora.usePreset ||
                     lora.modemPreset != ConfigProtos.Config.LoRaConfig.ModemPreset.SHORT_FAST ||
-                    lora.region != ConfigProtos.Config.LoRaConfig.RegionCode.EU_868 ||
+                    lora.region != ConfigProtos.Config.LoRaConfig.RegionCode.US ||
                     !lora.txEnabled ||
                     lora.hopLimit != 6) {
                     needsLoraConfig = true
@@ -944,7 +944,7 @@ class MeshtasticConfigManager(
             .setIgnoreMqtt(true)
             .setConfigOkToMqtt(false)
             .setOverrideDutyCycle(true)
-            .setRegion(ConfigProtos.Config.LoRaConfig.RegionCode.EU_868) // do this last?
+            .setRegion(ConfigProtos.Config.LoRaConfig.RegionCode.US)
             .build()
 
         val config = ConfigProtos.Config.newBuilder().setLora(loraConfig).build()

--- a/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/MeshtasticManager.kt
+++ b/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/MeshtasticManager.kt
@@ -930,12 +930,20 @@ class MeshtasticManager(private val context: Context) : RadioCallback {
     
     // Callback for device name updates
     private var deviceNameUpdateCallback: ((String) -> Unit)? = null
-    
+
     /**
      * Set callback for when device name is updated
      */
     fun setDeviceNameUpdateCallback(callback: (String) -> Unit) {
         deviceNameUpdateCallback = callback
+    }
+
+    // Callback fired whenever a Config response is received and cached. UI uses it to
+    // re-render fields like region/role after the device reboots post-reconfigure.
+    private var configUpdateCallback: (() -> Unit)? = null
+
+    fun setConfigUpdateCallback(callback: (() -> Unit)?) {
+        configUpdateCallback = callback
     }
     
     /**
@@ -1055,6 +1063,8 @@ class MeshtasticManager(private val context: Context) : RadioCallback {
                     Log.w(TAG, "❓ Unknown Config type received")
                 }
             }
+            // Poke the UI so cards reading getLoraConfig() / role / region pick up the new value.
+            configUpdateCallback?.invoke()
         } catch (e: Exception) {
             Log.e(TAG, "Error parsing Config: ${e.message}", e)
         }
@@ -1373,13 +1383,8 @@ class MeshtasticManager(private val context: Context) : RadioCallback {
                 Log.d(TAG, "Device log: ${fromRadio.logRecord}")
             }
 
-            fromRadio.clientNotification != null -> {
-                val cn = fromRadio.clientNotification
-                if (cn.message.startsWith(LockdownCoordinator.PREFIX)) {
-                    lockdownCoordinator.handleLockdownNotification(cn.message)
-                } else {
-                    Log.i(TAG, "ClientNotification: ${cn.message}")
-                }
+            fromRadio.lockdownStatus != null -> {
+                lockdownCoordinator.handleLockdownStatus(fromRadio.lockdownStatus)
             }
             
             fromRadio.routingError != null -> {
@@ -1631,13 +1636,11 @@ class MeshtasticManager(private val context: Context) : RadioCallback {
     
     // --- Lockdown wire format -------------------------------------------------------------
     //
-    // Send a `set_config(security)`-shaped AdminMessage that the locked firmware decodes as
-    // a passphrase submission. This is the string-prefix wire format from firmware PR #10349;
-    // protobufs PR #911 adds a structured AdminMessage.lockdown_auth field but the firmware
-    // still emits/consumes the SecurityConfig form, so that's what we target here.
+    // Outbound: AdminMessage.lockdown_auth (oneof tag 104) — typed schema from
+    // meshtastic/protobufs PR #911. Inbound: FromRadio.lockdown_status (oneof tag 18).
     //
-    // CRITICAL: every field below has to match exactly — the firmware ToRadio gate while
-    // locked is strict.
+    // CRITICAL: every MeshPacket field below has to match exactly — the firmware ToRadio
+    // gate while locked is strict.
     //   - to == myNodeNum                      (firmware checks this)
     //   - from == 0 (proto default, NOT SET)   (firmware uses from==0 as "local PhoneAPI")
     //   - portnum == ADMIN_APP
@@ -1650,28 +1653,20 @@ class MeshtasticManager(private val context: Context) : RadioCallback {
             Log.w(TAG, "Cannot send lockdown passphrase: myNodeInfo not yet received")
             return
         }
-        val adminKeyList: List<ByteString> = if (boots > 0 || hours > 0) {
-            val untilEpoch = if (hours > 0) System.currentTimeMillis() / 1000L + hours.toLong() * 3600L else 0L
-            val untilBytes = ByteArray(4).apply {
-                this[0] = (untilEpoch and 0xFF).toByte()
-                this[1] = ((untilEpoch shr 8) and 0xFF).toByte()
-                this[2] = ((untilEpoch shr 16) and 0xFF).toByte()
-                this[3] = ((untilEpoch shr 24) and 0xFF).toByte()
-            }
-            listOf(
-                ByteString.EMPTY,
-                ByteString.copyFrom(byteArrayOf(boots.coerceIn(1, 255).toByte())),
-                ByteString.copyFrom(untilBytes),
-            )
+        val validUntilEpoch: Int = if (hours > 0) {
+            // Absolute Unix-epoch seconds; firmware compares with its RTC.
+            ((System.currentTimeMillis() / 1000L) + hours.toLong() * 3600L).toInt()
         } else {
-            emptyList()
+            0
         }
-        val securityConfig = ConfigProtos.Config.SecurityConfig.newBuilder()
-            .setPrivateKey(ByteString.copyFrom(passphrase.toByteArray(Charsets.UTF_8)))
-            .also { b -> adminKeyList.forEach { b.addAdminKey(it) } }
+        val lockdownAuth = AdminProtos.LockdownAuth.newBuilder()
+            .setPassphrase(ByteString.copyFrom(passphrase.toByteArray(Charsets.UTF_8)))
+            .setBootsRemaining(boots.coerceAtLeast(0))
+            .setValidUntilEpoch(validUntilEpoch)
+            .setLockNow(false)
             .build()
         val adminMsg = AdminProtos.AdminMessage.newBuilder()
-            .setSetConfig(ConfigProtos.Config.newBuilder().setSecurity(securityConfig).build())
+            .setLockdownAuth(lockdownAuth)
             .build()
         sendLockdownAdmin(myNum, adminMsg.toByteArray(), label = "passphrase")
     }
@@ -1682,12 +1677,11 @@ class MeshtasticManager(private val context: Context) : RadioCallback {
             Log.w(TAG, "Cannot send Lock Now: myNodeInfo not yet received")
             return
         }
-        // Sentinel: SecurityConfig.private_key = single 0xFF byte → firmware treats as Lock Now.
-        val securityConfig = ConfigProtos.Config.SecurityConfig.newBuilder()
-            .setPrivateKey(ByteString.copyFrom(byteArrayOf(0xFF.toByte())))
+        val lockdownAuth = AdminProtos.LockdownAuth.newBuilder()
+            .setLockNow(true)
             .build()
         val adminMsg = AdminProtos.AdminMessage.newBuilder()
-            .setSetConfig(ConfigProtos.Config.newBuilder().setSecurity(securityConfig).build())
+            .setLockdownAuth(lockdownAuth)
             .build()
         sendLockdownAdmin(myNum, adminMsg.toByteArray(), label = "lock-now")
     }

--- a/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/MeshtasticManager.kt
+++ b/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/MeshtasticManager.kt
@@ -13,6 +13,7 @@ import com.geeksville.mesh.AdminProtos
 import com.geeksville.mesh.ConfigProtos
 import com.geeksville.mesh.TelemetryProtos
 import com.geeksville.mesh.Portnums
+import com.google.protobuf.ByteString
 
 /**
  * Result of a message acknowledgment
@@ -190,6 +191,23 @@ class MeshtasticManager(private val context: Context) : RadioCallback {
     }
     
     
+    // Lockdown coordinator — drives the passphrase / Lock Now flows when the connected
+    // device runs a MESHTASTIC_LOCKDOWN-hardened firmware build.
+    private val lockdownSender = object : LockdownSender {
+        override fun sendLockdownPassphrase(passphrase: String, boots: Int, hours: Int) {
+            this@MeshtasticManager.sendLockdownPassphrase(passphrase, boots, hours)
+        }
+        override fun sendLockNow() {
+            this@MeshtasticManager.sendLockNow()
+        }
+        override fun getDeviceAddress(): String? {
+            bluetoothInterface?.let { return it.deviceAddress }
+            usbInterface?.let { return "usb:${it.devicePath.ifEmpty { "default" }}" }
+            return null
+        }
+    }
+    val lockdownCoordinator: LockdownCoordinator = LockdownCoordinator(context, lockdownSender)
+
     init {
         startMessageProcessing()
     }
@@ -331,7 +349,9 @@ class MeshtasticManager(private val context: Context) : RadioCallback {
      */
     fun disconnect() {
         Log.i(TAG, "Disconnecting from Meshtastic device")
-        
+
+        lockdownCoordinator.onDisconnect()
+
         bluetoothInterface?.disconnect()
         bluetoothInterface = null
         
@@ -1352,6 +1372,15 @@ class MeshtasticManager(private val context: Context) : RadioCallback {
             fromRadio.logRecord != null -> {
                 Log.d(TAG, "Device log: ${fromRadio.logRecord}")
             }
+
+            fromRadio.clientNotification != null -> {
+                val cn = fromRadio.clientNotification
+                if (cn.message.startsWith(LockdownCoordinator.PREFIX)) {
+                    lockdownCoordinator.handleLockdownNotification(cn.message)
+                } else {
+                    Log.i(TAG, "ClientNotification: ${cn.message}")
+                }
+            }
             
             fromRadio.routingError != null -> {
                 // Handle routing error (packet failed to deliver)
@@ -1433,6 +1462,10 @@ class MeshtasticManager(private val context: Context) : RadioCallback {
      */
     override fun onConnect() {
         Log.i(TAG, "Radio connected, checking radio state...")
+
+        // Reset per-connection lockdown state. Firmware requires re-auth on every new
+        // connection, even if the device's storage is already unlocked.
+        lockdownCoordinator.onConnect()
 
         // Update connection state to CONNECTED
         _connectionState.value = ConnectionState.CONNECTED
@@ -1596,6 +1629,98 @@ class MeshtasticManager(private val context: Context) : RadioCallback {
         }
     }
     
+    // --- Lockdown wire format -------------------------------------------------------------
+    //
+    // Send a `set_config(security)`-shaped AdminMessage that the locked firmware decodes as
+    // a passphrase submission. This is the string-prefix wire format from firmware PR #10349;
+    // protobufs PR #911 adds a structured AdminMessage.lockdown_auth field but the firmware
+    // still emits/consumes the SecurityConfig form, so that's what we target here.
+    //
+    // CRITICAL: every field below has to match exactly — the firmware ToRadio gate while
+    // locked is strict.
+    //   - to == myNodeNum                      (firmware checks this)
+    //   - from == 0 (proto default, NOT SET)   (firmware uses from==0 as "local PhoneAPI")
+    //   - portnum == ADMIN_APP
+    //   - decoded payload (not encrypted)
+    //   - pki_encrypted == false               (firmware drops PKI-encrypted ToRadio while locked)
+    //   - hop_limit / hop_start == 7, priority == RELIABLE
+    fun sendLockdownPassphrase(passphrase: String, boots: Int, hours: Int) {
+        val myNum = myNodeInfo?.myNodeNum?.toInt()
+        if (myNum == null) {
+            Log.w(TAG, "Cannot send lockdown passphrase: myNodeInfo not yet received")
+            return
+        }
+        val adminKeyList: List<ByteString> = if (boots > 0 || hours > 0) {
+            val untilEpoch = if (hours > 0) System.currentTimeMillis() / 1000L + hours.toLong() * 3600L else 0L
+            val untilBytes = ByteArray(4).apply {
+                this[0] = (untilEpoch and 0xFF).toByte()
+                this[1] = ((untilEpoch shr 8) and 0xFF).toByte()
+                this[2] = ((untilEpoch shr 16) and 0xFF).toByte()
+                this[3] = ((untilEpoch shr 24) and 0xFF).toByte()
+            }
+            listOf(
+                ByteString.EMPTY,
+                ByteString.copyFrom(byteArrayOf(boots.coerceIn(1, 255).toByte())),
+                ByteString.copyFrom(untilBytes),
+            )
+        } else {
+            emptyList()
+        }
+        val securityConfig = ConfigProtos.Config.SecurityConfig.newBuilder()
+            .setPrivateKey(ByteString.copyFrom(passphrase.toByteArray(Charsets.UTF_8)))
+            .also { b -> adminKeyList.forEach { b.addAdminKey(it) } }
+            .build()
+        val adminMsg = AdminProtos.AdminMessage.newBuilder()
+            .setSetConfig(ConfigProtos.Config.newBuilder().setSecurity(securityConfig).build())
+            .build()
+        sendLockdownAdmin(myNum, adminMsg.toByteArray(), label = "passphrase")
+    }
+
+    fun sendLockNow() {
+        val myNum = myNodeInfo?.myNodeNum?.toInt()
+        if (myNum == null) {
+            Log.w(TAG, "Cannot send Lock Now: myNodeInfo not yet received")
+            return
+        }
+        // Sentinel: SecurityConfig.private_key = single 0xFF byte → firmware treats as Lock Now.
+        val securityConfig = ConfigProtos.Config.SecurityConfig.newBuilder()
+            .setPrivateKey(ByteString.copyFrom(byteArrayOf(0xFF.toByte())))
+            .build()
+        val adminMsg = AdminProtos.AdminMessage.newBuilder()
+            .setSetConfig(ConfigProtos.Config.newBuilder().setSecurity(securityConfig).build())
+            .build()
+        sendLockdownAdmin(myNum, adminMsg.toByteArray(), label = "lock-now")
+    }
+
+    private fun sendLockdownAdmin(myNum: Int, payload: ByteArray, label: String) {
+        val data = GeneratedMeshProtos.Data.newBuilder()
+            .setPortnum(Portnums.PortNum.ADMIN_APP)
+            .setPayload(ByteString.copyFrom(payload))
+            .build()
+        // NOTE: leave `from` unset (proto default = 0). The firmware lockdown path requires
+        // from == 0 ("local PhoneAPI"); never set pki_encrypted here.
+        val packet = GeneratedMeshProtos.MeshPacket.newBuilder()
+            .setTo(myNum)
+            .setId(MeshProtos.DataPacket.generatePacketId())
+            .setChannel(0)
+            .setWantAck(true)
+            .setHopLimit(7)
+            .setHopStart(7)
+            .setPriority(GeneratedMeshProtos.MeshPacket.Priority.RELIABLE)
+            .setDecoded(data)
+            .build()
+        val toRadio = GeneratedMeshProtos.ToRadio.newBuilder()
+            .setPacket(packet)
+            .build()
+        Log.i(TAG, "Sending lockdown admin packet: $label (to=0x${myNum.toLong().and(0xFFFFFFFFL).toString(16)})")
+        val bytes = toRadio.toByteArray()
+        when {
+            bluetoothInterface != null -> bluetoothInterface?.sendData(bytes)
+            usbInterface != null -> usbInterface?.sendData(bytes)
+            else -> Log.w(TAG, "No interface available to send lockdown admin packet")
+        }
+    }
+
     private fun sendConfigRequest() {
         // Send wantConfig request to fetch device configuration
         // Using same approach as official Meshtastic-Android app

--- a/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/UsbSerialInterface.kt
+++ b/app/src/main/java/com/atakmap/android/pluginmeshtastic/meshtastic/UsbSerialInterface.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.LinkedBlockingQueue
 
 class UsbSerialInterface(
     private val context: Context,
-    private val devicePath: String,
+    val devicePath: String,
     private val callback: RadioCallback
 ) : SerialInputOutputManager.Listener {
     

--- a/app/src/main/proto/meshtastic/admin.proto
+++ b/app/src/main/proto/meshtastic/admin.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package meshtastic;
 
+/* trunk-ignore(buf-lint/COMPILE) */
 import "meshtastic/channel.proto";
 import "meshtastic/config.proto";
 import "meshtastic/connection_status.proto";
@@ -151,6 +152,21 @@ message AdminMessage {
      * TODO: REPLACE
      */
     PAXCOUNTER_CONFIG = 12;
+
+    /*
+     * TODO: REPLACE
+     */
+    STATUSMESSAGE_CONFIG = 13;
+
+    /*
+     * Traffic management module config
+     */
+    TRAFFICMANAGEMENT_CONFIG = 14;
+
+    /*
+     * TAK module config
+     */
+    TAK_CONFIG = 15;
   }
 
   enum BackupLocation {
@@ -185,6 +201,23 @@ message AdminMessage {
      * The touch Y coordinate
      */
     uint32 touch_y = 4;
+  }
+
+  /*
+   * User is requesting an over the air update.
+   * Node will reboot into the OTA loader
+   */
+  message OTAEvent {
+    /*
+     * Tell the node to reboot into OTA mode for firmware update via BLE or WiFi (ESP32 only for now)
+     */
+    OTAMode reboot_ota_mode = 1;
+
+    /*
+     * A 32 byte hash of the OTA firmware.
+     * Used to verify the integrity of the firmware before applying an update.
+     */
+    bytes ota_hash = 2;
   }
 
   /*
@@ -415,6 +448,11 @@ message AdminMessage {
     uint32 remove_ignored_node = 48;
 
     /*
+     * Set specified node-num to be muted
+     */
+    uint32 toggle_muted_node = 49;
+
+    /*
      * Begins an edit transaction for config, module config, owner, and channel settings changes
      * This will delay the standard *implicit* save to the file system and subsequent reboot behavior until committed (commit_edit_settings)
      */
@@ -443,8 +481,9 @@ message AdminMessage {
     /*
      * Tell the node to reboot into the OTA Firmware in this many seconds (or <0 to cancel reboot)
      * Only Implemented for ESP32 Devices. This needs to be issued to send a new main firmware via bluetooth.
+     * Deprecated in favor of reboot_ota_mode in 2.7.17
      */
-    int32 reboot_ota_seconds = 95;
+    int32 reboot_ota_seconds = 95 [deprecated = true];
 
     /*
      * This message is only supported for the simulator Portduino build.
@@ -469,9 +508,99 @@ message AdminMessage {
 
     /*
      * Tell the node to reset the nodedb.
+     * When true, favorites are preserved through reset.
      */
-    int32 nodedb_reset = 100;
+    bool nodedb_reset = 100;
+
+    /*
+     * Tell the node to reset into the OTA Loader
+     */
+    OTAEvent ota_request = 102;
+
+    /*
+     * Parameters and sensor configuration
+     */
+    SensorConfig sensor_config = 103;
+
+    /*
+     * Lockdown passphrase delivery / unlock / lock-now command for hardened
+     * firmware builds (see MESHTASTIC_LOCKDOWN). Used to provision the
+     * passphrase on first boot, unlock encrypted storage on subsequent
+     * reboots, re-verify on already-unlocked devices to authorize a new
+     * client connection, or immediately re-lock the device.
+     *
+     * Replaces the earlier scheme that repurposed SecurityConfig.private_key
+     * to carry passphrase bytes; that hack is retired.
+     */
+    LockdownAuth lockdown_auth = 104;
   }
+}
+
+/*
+ * Lockdown passphrase delivery payload.
+ *
+ * One message handles three operations distinguished by content:
+ *   - Provision (first-time): passphrase set, lock_now=false. Firmware
+ *     generates DEK, wraps with passphrase-derived KEK, persists.
+ *   - Unlock: passphrase set, lock_now=false. Firmware verifies
+ *     passphrase against stored DEK, unlocks storage, authorizes the
+ *     connection that delivered this packet.
+ *   - Lock now: lock_now=true, passphrase ignored. Firmware revokes
+ *     all client auth and reboots into the locked state.
+ *
+ * Firmware decides between provision and unlock based on its own state
+ * (whether a DEK file already exists). Clients do not need to track
+ * which case applies.
+ */
+message LockdownAuth {
+  /*
+   * Passphrase bytes (1-32). Empty when lock_now is true.
+   * Capped to 32 to match the proto cap on related security fields.
+   */
+  bytes passphrase = 1;
+
+  /*
+   * Optional override of the boot-count token TTL granted on success.
+   * 0 = use firmware default (TOKEN_DEFAULT_BOOTS).
+   * On reboot the firmware decrements this; when it reaches 0 the
+   * device boots fully locked and requires a fresh passphrase.
+   */
+  uint32 boots_remaining = 2;
+
+  /*
+   * Optional wall-clock expiry for the unlock token, as absolute
+   * Unix-epoch seconds. 0 = no time limit (only the boot-count TTL
+   * applies). On boot, if the device RTC is set and now > this value,
+   * the token is treated as expired.
+   */
+  uint32 valid_until_epoch = 3;
+
+  /*
+   * If true, ignore passphrase fields, immediately revoke all
+   * connection-level admin authorization, and reboot the device into
+   * the locked state. Always honoured regardless of current lock state.
+   */
+  bool lock_now = 4;
+}
+
+/*
+ * Firmware update mode for OTA updates
+ */
+enum OTAMode {
+  /*
+   * Do not reboot into OTA mode
+   */
+  NO_REBOOT_OTA = 0;
+
+  /*
+   * Reboot into OTA mode for BLE firmware update
+   */
+  OTA_BLE = 1;
+
+  /*
+   * Reboot into OTA mode for WiFi firmware update
+   */
+  OTA_WIFI = 2;
 }
 
 /*
@@ -526,6 +655,11 @@ message SharedContact {
    * Add this contact to the blocked / ignored list
    */
   bool should_ignore = 3;
+
+  /*
+   * Set the IS_KEY_MANUALLY_VERIFIED bit
+   */
+  bool manually_verified = 4;
 }
 
 /*
@@ -574,4 +708,114 @@ message KeyVerificationAdmin {
    * The 4 digit code generated by the remote node, and communicated outside the mesh
    */
   optional uint32 security_number = 4;
+}
+
+message SensorConfig {
+  /*
+   * SCD4X CO2 Sensor configuration
+   */
+  SCD4X_config scd4x_config = 1;
+
+  /*
+   * SEN5X PM Sensor configuration
+   */
+  SEN5X_config sen5x_config = 2;
+
+  /*
+   * SCD30 CO2 Sensor configuration
+   */
+  SCD30_config scd30_config = 3;
+
+  /*
+   * SHTXX temperature and relative humidity sensor configuration
+   */
+  SHTXX_config shtxx_config = 4;
+}
+
+message SCD4X_config {
+  /*
+   * Set Automatic self-calibration enabled
+   */
+  optional bool set_asc = 1;
+
+  /*
+   * Recalibration target CO2 concentration in ppm (FRC or ASC)
+   */
+  optional uint32 set_target_co2_conc = 2;
+
+  /*
+   * Reference temperature in degC
+   */
+  optional float set_temperature = 3;
+
+  /*
+   * Altitude of sensor in meters above sea level. 0 - 3000m (overrides ambient pressure)
+   */
+  optional uint32 set_altitude = 4;
+
+  /*
+   * Sensor ambient pressure in Pa. 70000 - 120000 Pa (overrides altitude)
+   */
+  optional uint32 set_ambient_pressure = 5;
+
+  /*
+   * Perform a factory reset of the sensor
+   */
+  optional bool factory_reset = 6;
+
+  /*
+   * Power mode for sensor (true for low power, false for normal)
+   */
+  optional bool set_power_mode = 7;
+}
+
+message SEN5X_config {
+  /*
+   * Reference temperature in degC
+   */
+  optional float set_temperature = 1;
+
+  /*
+   * One-shot mode (true for low power - one-shot mode, false for normal - continuous mode)
+   */
+  optional bool set_one_shot_mode = 2;
+}
+
+message SCD30_config {
+  /*
+   * Set Automatic self-calibration enabled
+   */
+  optional bool set_asc = 1;
+
+  /*
+   * Recalibration target CO2 concentration in ppm (FRC or ASC)
+   */
+  optional uint32 set_target_co2_conc = 2;
+
+  /*
+   * Reference temperature in degC
+   */
+  optional float set_temperature = 3;
+
+  /*
+   * Altitude of sensor in meters above sea level. 0 - 3000m (overrides ambient pressure)
+   */
+  optional uint32 set_altitude = 4;
+
+  /*
+   * Power mode for sensor (true for low power, false for normal)
+   */
+  optional uint32 set_measurement_interval = 5;
+
+  /*
+   * Perform a factory reset of the sensor
+   */
+  optional bool soft_reset = 6;
+}
+
+message SHTXX_config {
+  /*
+   * Accuracy mode (0 = low, 1 = medium, 2 = high)
+   */
+  optional uint32 set_accuracy = 1;
 }

--- a/app/src/main/proto/meshtastic/atak.proto
+++ b/app/src/main/proto/meshtastic/atak.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+/* trunk-ignore(buf-lint/PACKAGE_DIRECTORY_MATCH) */
 package meshtastic;
 
 option csharp_namespace = "Meshtastic.Protobufs";
@@ -54,7 +55,21 @@ message TAKPacket {
  */
 message GeoChat {
   /*
-   * The text message
+   * Receipt discriminator. Set alongside cot_type_id = b-t-f-d (delivered)
+   * or b-t-f-r (read). ReceiptType_None is the default for a normal chat
+   * message (cot_type_id = b-t-f).
+   *
+   * Receivers can detect a receipt by checking receipt_type != ReceiptType_None
+   * without re-parsing the envelope cot_type_id.
+   */
+  enum ReceiptType {
+    ReceiptType_None = 0; // normal chat message
+    ReceiptType_Delivered = 1; // b-t-f-d delivered receipt
+    ReceiptType_Read = 2; // b-t-f-r read receipt
+  }
+
+  /*
+   * The text message. Empty for receipts.
    */
   string message = 1;
 
@@ -67,6 +82,20 @@ message GeoChat {
    * Callsign of the recipient for the message
    */
   optional string to_callsign = 3;
+
+  /*
+   * UID of the chat message this event is acknowledging. Empty for a
+   * normal chat message; set for delivered / read receipts. Paired with
+   * receipt_type so receivers can match the ack back to the original
+   * outbound GeoChat by its event uid.
+   */
+  string receipt_for_uid = 4;
+
+  /*
+   * Receipt kind discriminator. See ReceiptType doc. Default ReceiptType_None
+   * means this is a regular chat message, not a receipt.
+   */
+  ReceiptType receipt_type = 5;
 }
 
 /*
@@ -260,4 +289,1729 @@ message PLI {
    * Course in degrees
    */
   uint32 course = 5;
+}
+
+/*
+ * CoT how field values.
+ * Represents how the coordinates were generated.
+ */
+enum CotHow {
+  /*
+   * Unspecified
+   */
+  CotHow_Unspecified = 0;
+  /*
+   * Human entered
+   */
+  CotHow_h_e = 1;
+  /*
+   * Machine generated
+   */
+  CotHow_m_g = 2;
+  /*
+   * Human GPS/INS derived
+   */
+  CotHow_h_g_i_g_o = 3;
+  /*
+   * Machine relayed (imported from another system/gateway)
+   */
+  CotHow_m_r = 4;
+  /*
+   * Machine fused (corroborated from multiple sources)
+   */
+  CotHow_m_f = 5;
+  /*
+   * Machine predicted
+   */
+  CotHow_m_p = 6;
+  /*
+   * Machine simulated
+   */
+  CotHow_m_s = 7;
+}
+
+/*
+ * Well-known CoT event types.
+ * When the type is known, use the enum value for efficient encoding.
+ * For unknown types, set cot_type_id to CotType_Other and populate cot_type_str.
+ */
+enum CotType {
+  /*
+   * Unknown or unmapped type, use cot_type_str
+   */
+  CotType_Other = 0;
+  /*
+   * a-f-G-U-C: Friendly ground unit combat
+   */
+  CotType_a_f_G_U_C = 1;
+  /*
+   * a-f-G-U-C-I: Friendly ground unit combat infantry
+   */
+  CotType_a_f_G_U_C_I = 2;
+  /*
+   * a-n-A-C-F: Neutral aircraft civilian fixed-wing
+   */
+  CotType_a_n_A_C_F = 3;
+  /*
+   * a-n-A-C-H: Neutral aircraft civilian helicopter
+   */
+  CotType_a_n_A_C_H = 4;
+  /*
+   * a-n-A-C: Neutral aircraft civilian
+   */
+  CotType_a_n_A_C = 5;
+  /*
+   * a-f-A-M-H: Friendly aircraft military helicopter
+   */
+  CotType_a_f_A_M_H = 6;
+  /*
+   * a-f-A-M: Friendly aircraft military
+   */
+  CotType_a_f_A_M = 7;
+  /*
+   * a-f-A-M-F-F: Friendly aircraft military fixed-wing fighter
+   */
+  CotType_a_f_A_M_F_F = 8;
+  /*
+   * a-f-A-M-H-A: Friendly aircraft military helicopter attack
+   */
+  CotType_a_f_A_M_H_A = 9;
+  /*
+   * a-f-A-M-H-U-M: Friendly aircraft military helicopter utility medium
+   */
+  CotType_a_f_A_M_H_U_M = 10;
+  /*
+   * a-h-A-M-F-F: Hostile aircraft military fixed-wing fighter
+   */
+  CotType_a_h_A_M_F_F = 11;
+  /*
+   * a-h-A-M-H-A: Hostile aircraft military helicopter attack
+   */
+  CotType_a_h_A_M_H_A = 12;
+  /*
+   * a-u-A-C: Unknown aircraft civilian
+   */
+  CotType_a_u_A_C = 13;
+  /*
+   * t-x-d-d: Tasking delete/disconnect
+   */
+  CotType_t_x_d_d = 14;
+  /*
+   * a-f-G-E-S-E: Friendly ground equipment sensor
+   */
+  CotType_a_f_G_E_S_E = 15;
+  /*
+   * a-f-G-E-V-C: Friendly ground equipment vehicle
+   */
+  CotType_a_f_G_E_V_C = 16;
+  /*
+   * a-f-S: Friendly sea
+   */
+  CotType_a_f_S = 17;
+  /*
+   * a-f-A-M-F: Friendly aircraft military fixed-wing
+   */
+  CotType_a_f_A_M_F = 18;
+  /*
+   * a-f-A-M-F-C-H: Friendly aircraft military fixed-wing cargo heavy
+   */
+  CotType_a_f_A_M_F_C_H = 19;
+  /*
+   * a-f-A-M-F-U-L: Friendly aircraft military fixed-wing utility light
+   */
+  CotType_a_f_A_M_F_U_L = 20;
+  /*
+   * a-f-A-M-F-L: Friendly aircraft military fixed-wing liaison
+   */
+  CotType_a_f_A_M_F_L = 21;
+  /*
+   * a-f-A-M-F-P: Friendly aircraft military fixed-wing patrol
+   */
+  CotType_a_f_A_M_F_P = 22;
+  /*
+   * a-f-A-C-H: Friendly aircraft civilian helicopter
+   */
+  CotType_a_f_A_C_H = 23;
+  /*
+   * a-n-A-M-F-Q: Neutral aircraft military fixed-wing drone
+   */
+  CotType_a_n_A_M_F_Q = 24;
+
+  // --- Chat / messaging ---
+
+  /*
+   * b-t-f: GeoChat message
+   */
+  CotType_b_t_f = 25;
+
+  // --- CASEVAC / MEDEVAC ---
+
+  /*
+   * b-r-f-h-c: CASEVAC/MEDEVAC report
+   */
+  CotType_b_r_f_h_c = 26;
+
+  // --- Alerts ---
+
+  /*
+   * b-a-o-pan: Ring the bell / alert all
+   */
+  CotType_b_a_o_pan = 27;
+  /*
+   * b-a-o-opn: Troops in contact
+   */
+  CotType_b_a_o_opn = 28;
+  /*
+   * b-a-o-can: Cancel alert
+   */
+  CotType_b_a_o_can = 29;
+  /*
+   * b-a-o-tbl: 911 alert
+   */
+  CotType_b_a_o_tbl = 30;
+  /*
+   * b-a-g: Geofence breach alert
+   */
+  CotType_b_a_g = 31;
+
+  // --- Generic ground atoms (simplified affiliation types) ---
+
+  /*
+   * a-f-G: Friendly ground (generic)
+   */
+  CotType_a_f_G = 32;
+  /*
+   * a-f-G-U: Friendly ground unit (generic)
+   */
+  CotType_a_f_G_U = 33;
+  /*
+   * a-h-G: Hostile ground (generic)
+   */
+  CotType_a_h_G = 34;
+  /*
+   * a-u-G: Unknown ground (generic)
+   */
+  CotType_a_u_G = 35;
+  /*
+   * a-n-G: Neutral ground (generic)
+   */
+  CotType_a_n_G = 36;
+
+  // --- Routes and waypoints ---
+
+  /*
+   * b-m-r: Route
+   */
+  CotType_b_m_r = 37;
+  /*
+   * b-m-p-w: Route waypoint
+   */
+  CotType_b_m_p_w = 38;
+  /*
+   * b-m-p-s-p-i: Self-position marker
+   */
+  CotType_b_m_p_s_p_i = 39;
+
+  // --- Drawing / tactical graphics ---
+
+  /*
+   * u-d-f: Freeform shape (line/polygon)
+   */
+  CotType_u_d_f = 40;
+  /*
+   * u-d-r: Rectangle
+   */
+  CotType_u_d_r = 41;
+  /*
+   * u-d-c-c: Circle
+   */
+  CotType_u_d_c_c = 42;
+  /*
+   * u-rb-a: Range/bearing line
+   */
+  CotType_u_rb_a = 43;
+
+  // --- Additional hostile/unknown aircraft ---
+
+  /*
+   * a-h-A: Hostile aircraft (generic)
+   */
+  CotType_a_h_A = 44;
+  /*
+   * a-u-A: Unknown aircraft (generic)
+   */
+  CotType_a_u_A = 45;
+  /*
+   * a-f-A-M-H-Q: Friendly aircraft military helicopter observation
+   */
+  CotType_a_f_A_M_H_Q = 46;
+
+  // Friendly aircraft civilian
+
+  /*
+   * a-f-A-C-F: Friendly aircraft civilian fixed-wing
+   */
+  CotType_a_f_A_C_F = 47;
+  /*
+   * a-f-A-C: Friendly aircraft civilian (generic)
+   */
+  CotType_a_f_A_C = 48;
+  /*
+   * a-f-A-C-L: Friendly aircraft civilian lighter-than-air
+   */
+  CotType_a_f_A_C_L = 49;
+  /*
+   * a-f-A: Friendly aircraft (generic)
+   */
+  CotType_a_f_A = 50;
+
+  // Friendly aircraft military helicopter variants
+
+  /*
+   * a-f-A-M-H-C: Friendly aircraft military helicopter cargo
+   */
+  CotType_a_f_A_M_H_C = 51;
+
+  // Neutral aircraft military
+
+  /*
+   * a-n-A-M-F-F: Neutral aircraft military fixed-wing fighter
+   */
+  CotType_a_n_A_M_F_F = 52;
+
+  // Unknown aircraft civilian
+
+  /*
+   * a-u-A-C-F: Unknown aircraft civilian fixed-wing
+   */
+  CotType_a_u_A_C_F = 53;
+
+  // Friendly ground unit subtypes
+
+  /*
+   * a-f-G-U-C-F-T-A: Friendly ground unit combat forces theater aviation
+   */
+  CotType_a_f_G_U_C_F_T_A = 54;
+  /*
+   * a-f-G-U-C-V-S: Friendly ground unit combat vehicle support
+   */
+  CotType_a_f_G_U_C_V_S = 55;
+  /*
+   * a-f-G-U-C-R-X: Friendly ground unit combat reconnaissance exploitation
+   */
+  CotType_a_f_G_U_C_R_X = 56;
+  /*
+   * a-f-G-U-C-I-Z: Friendly ground unit combat infantry mechanized
+   */
+  CotType_a_f_G_U_C_I_Z = 57;
+  /*
+   * a-f-G-U-C-E-C-W: Friendly ground unit combat engineer construction wheeled
+   */
+  CotType_a_f_G_U_C_E_C_W = 58;
+  /*
+   * a-f-G-U-C-I-L: Friendly ground unit combat infantry light
+   */
+  CotType_a_f_G_U_C_I_L = 59;
+  /*
+   * a-f-G-U-C-R-O: Friendly ground unit combat reconnaissance other
+   */
+  CotType_a_f_G_U_C_R_O = 60;
+  /*
+   * a-f-G-U-C-R-V: Friendly ground unit combat reconnaissance cavalry
+   */
+  CotType_a_f_G_U_C_R_V = 61;
+  /*
+   * a-f-G-U-H: Friendly ground unit headquarters
+   */
+  CotType_a_f_G_U_H = 62;
+  /*
+   * a-f-G-U-U-M-S-E: Friendly ground unit support medical surgical evacuation
+   */
+  CotType_a_f_G_U_U_M_S_E = 63;
+  /*
+   * a-f-G-U-S-M-C: Friendly ground unit support maintenance collection
+   */
+  CotType_a_f_G_U_S_M_C = 64;
+
+  // Friendly ground equipment
+
+  /*
+   * a-f-G-E-S: Friendly ground equipment sensor (generic)
+   */
+  CotType_a_f_G_E_S = 65;
+  /*
+   * a-f-G-E: Friendly ground equipment (generic)
+   */
+  CotType_a_f_G_E = 66;
+  /*
+   * a-f-G-E-V-C-U: Friendly ground equipment vehicle utility
+   */
+  CotType_a_f_G_E_V_C_U = 67;
+  /*
+   * a-f-G-E-V-C-ps: Friendly ground equipment vehicle public safety
+   */
+  CotType_a_f_G_E_V_C_ps = 68;
+
+  // Unknown ground
+
+  /*
+   * a-u-G-E-V: Unknown ground equipment vehicle
+   */
+  CotType_a_u_G_E_V = 69;
+
+  // Sea
+
+  /*
+   * a-f-S-N-N-R: Friendly sea surface non-naval rescue
+   */
+  CotType_a_f_S_N_N_R = 70;
+
+  // Friendly force (non-domain-specific)
+
+  /*
+   * a-f-F-B: Friendly force boundary
+   */
+  CotType_a_f_F_B = 71;
+
+  // Bits / data messages
+
+  /*
+   * b-m-p-s-p-loc: Self-position location marker
+   */
+  CotType_b_m_p_s_p_loc = 72;
+  /*
+   * b-i-v: Imagery/video
+   */
+  CotType_b_i_v = 73;
+  /*
+   * b-f-t-r: File transfer request
+   */
+  CotType_b_f_t_r = 74;
+  /*
+   * b-f-t-a: File transfer acknowledgment
+   */
+  CotType_b_f_t_a = 75;
+
+  // --- Additional drawing / tactical graphics ---
+
+  /*
+   * u-d-f-m: Freehand telestration / annotation. Anchor at event point,
+   * geometry carried via DrawnShape.vertices. May be truncated to
+   * MAX_VERTICES by the sender.
+   */
+  CotType_u_d_f_m = 76;
+  /*
+   * u-d-p: Closed polygon. Geometry carried via DrawnShape.vertices,
+   * implicitly closed (receiver duplicates first vertex as needed).
+   */
+  CotType_u_d_p = 77;
+
+  // --- Additional markers ---
+
+  /*
+   * b-m-p-s-m: Spot map marker (colored dot at a point of interest).
+   */
+  CotType_b_m_p_s_m = 78;
+  /*
+   * b-m-p-c: Checkpoint (intermediate route control point).
+   */
+  CotType_b_m_p_c = 79;
+
+  // --- Ranging tools ---
+
+  /*
+   * u-r-b-c-c: Ranging circle (range rings centered on the event point).
+   */
+  CotType_u_r_b_c_c = 80;
+  /*
+   * u-r-b-bullseye: Bullseye with configurable range rings and bearing
+   * reference (magnetic / true / grid).
+   */
+  CotType_u_r_b_bullseye = 81;
+
+  // ======================================================================
+  // Expanded coverage from the ATAK-CIV quick-drop pallet (values 82-124).
+  // ======================================================================
+  //
+  // All of these types existed as cot_type_str strings; promoting them to
+  // enum values turns a ~10-byte string into a 1-byte varint on the wire
+  // for every event that uses them. Grouped below by pallet section.
+
+  // --- PLI self-reporting (1) ------------------------------------------
+  /*
+   * a-f-G-E-V-A: Friendly armored vehicle, user-selectable self PLI.
+   */
+  CotType_a_f_G_E_V_A = 82;
+
+  // --- 2525 quick-drop: basic affiliation gaps -------------------------
+  /*
+   * a-n-A: Neutral aircraft (friendly/hostile/unknown already present).
+   */
+  CotType_a_n_A = 83;
+
+  // --- 2525 quick-drop: artillery (4) ----------------------------------
+  CotType_a_u_G_U_C_F = 84;
+  CotType_a_n_G_U_C_F = 85;
+  CotType_a_h_G_U_C_F = 86;
+  CotType_a_f_G_U_C_F = 87;
+
+  // --- 2525 quick-drop: building (4) -----------------------------------
+  CotType_a_u_G_I = 88;
+  CotType_a_n_G_I = 89;
+  CotType_a_h_G_I = 90;
+  CotType_a_f_G_I = 91;
+
+  // --- 2525 quick-drop: mine (4) ---------------------------------------
+  CotType_a_u_G_E_X_M = 92;
+  CotType_a_n_G_E_X_M = 93;
+  CotType_a_h_G_E_X_M = 94;
+  CotType_a_f_G_E_X_M = 95;
+
+  // --- 2525 quick-drop: ship (3; a-f-S already at 17) ------------------
+  CotType_a_u_S = 96;
+  CotType_a_n_S = 97;
+  CotType_a_h_S = 98;
+
+  // --- 2525 quick-drop: sniper (4) -------------------------------------
+  CotType_a_u_G_U_C_I_d = 99;
+  CotType_a_n_G_U_C_I_d = 100;
+  CotType_a_h_G_U_C_I_d = 101;
+  CotType_a_f_G_U_C_I_d = 102;
+
+  // --- 2525 quick-drop: tank (4) ---------------------------------------
+  CotType_a_u_G_E_V_A_T = 103;
+  CotType_a_n_G_E_V_A_T = 104;
+  CotType_a_h_G_E_V_A_T = 105;
+  CotType_a_f_G_E_V_A_T = 106;
+
+  // --- 2525 quick-drop: troops (3; a-f-G-U-C-I already at 2) -----------
+  CotType_a_u_G_U_C_I = 107;
+  CotType_a_n_G_U_C_I = 108;
+  CotType_a_h_G_U_C_I = 109;
+
+  // --- 2525 quick-drop: generic vehicle (3; a-u-G-E-V already at 69) ---
+  CotType_a_n_G_E_V = 110;
+  CotType_a_h_G_E_V = 111;
+  CotType_a_f_G_E_V = 112;
+
+  // --- Mission-specific points (4) -------------------------------------
+  /*
+   * b-m-p-w-GOTO: Go To / bloodhound navigation target.
+   */
+  CotType_b_m_p_w_GOTO = 113;
+  /*
+   * b-m-p-c-ip: Initial point (mission planning).
+   */
+  CotType_b_m_p_c_ip = 114;
+  /*
+   * b-m-p-c-cp: Contact point (mission planning).
+   */
+  CotType_b_m_p_c_cp = 115;
+  /*
+   * b-m-p-s-p-op: Observation post.
+   */
+  CotType_b_m_p_s_p_op = 116;
+
+  // --- Vehicle drawings (2) --------------------------------------------
+  /*
+   * u-d-v: 2D vehicle outline drawn on the map.
+   */
+  CotType_u_d_v = 117;
+  /*
+   * u-d-v-m: 3D vehicle model reference.
+   */
+  CotType_u_d_v_m = 118;
+
+  // --- Drawing shapes (1) ----------------------------------------------
+  /*
+   * u-d-c-e: Non-circular ellipse (circle with distinct major/minor axes).
+   */
+  CotType_u_d_c_e = 119;
+
+  // --- Image / media marker (1) ----------------------------------------
+  /*
+   * b-i-x-i: Quick Pic geotagged image marker. The image itself does not
+   * ride on LoRa; this event references the image via iconset metadata.
+   */
+  CotType_b_i_x_i = 120;
+
+  // --- GeoChat receipts (2) --------------------------------------------
+  /*
+   * b-t-f-d: GeoChat delivered receipt. Carried on the existing `chat`
+   * payload_variant via GeoChat.receipt_for_uid + receipt_type.
+   */
+  CotType_b_t_f_d = 121;
+  /*
+   * b-t-f-r: GeoChat read receipt. Same wire slot as b-t-f-d.
+   */
+  CotType_b_t_f_r = 122;
+
+  // --- Custom emergency (1) --------------------------------------------
+  /*
+   * b-a-o-c: Custom / generic emergency beacon.
+   */
+  CotType_b_a_o_c = 123;
+
+  // --- Tasking (1) -----------------------------------------------------
+  /*
+   * t-s: Task / engage request. Structured payload carried via the new
+   * TaskRequest typed variant.
+   */
+  CotType_t_s = 124;
+}
+
+/*
+ * Geopoint and altitude source
+ */
+enum GeoPointSource {
+  /*
+   * Unspecified
+   */
+  GeoPointSource_Unspecified = 0;
+  /*
+   * GPS derived
+   */
+  GeoPointSource_GPS = 1;
+  /*
+   * User entered
+   */
+  GeoPointSource_USER = 2;
+  /*
+   * Network/external
+   */
+  GeoPointSource_NETWORK = 3;
+}
+
+/*
+ * Aircraft track information from ADS-B or military air tracking.
+ * Covers the majority of observed real-world CoT traffic.
+ */
+message AircraftTrack {
+  /*
+   * ICAO hex identifier (e.g. "AD237C")
+   */
+  string icao = 1;
+  /*
+   * Aircraft registration (e.g. "N946AK")
+   */
+  string registration = 2;
+  /*
+   * Flight number/callsign (e.g. "ASA864")
+   */
+  string flight = 3;
+  /*
+   * ICAO aircraft type designator (e.g. "B39M")
+   */
+  string aircraft_type = 4;
+  /*
+   * Transponder squawk code (0-7777 octal)
+   */
+  uint32 squawk = 5;
+  /*
+   * ADS-B emitter category (e.g. "A3")
+   */
+  string category = 6;
+  /*
+   * Received signal strength * 10 (e.g. -194 for -19.4 dBm)
+   */
+  sint32 rssi_x10 = 7;
+  /*
+   * Whether receiver has GPS fix
+   */
+  bool gps = 8;
+  /*
+   * CoT host ID for source attribution
+   */
+  string cot_host_id = 9;
+}
+
+/*
+ * Compact geographic vertex used by repeated vertex lists in TAK geometry
+ * payloads. Named with a `Cot` prefix to avoid a namespace collision with
+ * `meshtastic.GeoPoint` in `device_ui.proto`, which is an unrelated zoom/
+ * latitude/longitude type used by the on-device map UI.
+ *
+ * Encoded as a signed DELTA from TAKPacketV2.latitude_i / longitude_i (the
+ * enclosing event's anchor point). The absolute coordinate is recovered by
+ * the receiver as `event.latitude_i + vertex.lat_delta_i` (and likewise for
+ * longitude).
+ *
+ * Why deltas: a 32-vertex telestration with vertices clustered within a few
+ * hundred meters of the anchor has per-vertex deltas in the ±10^4 range.
+ * Under sint32+zigzag those encode as 2 bytes each (tag+varint), versus the
+ * 4 bytes that sfixed32 would always require. At 32 vertices that is ~128
+ * bytes of savings — the difference between fitting under the LoRa MTU or
+ * not. Absolute coordinates (values ~10^9) would cost sint32 varint 5 bytes
+ * per field, which is why TAKPacketV2's top-level latitude_i / longitude_i
+ * stay sfixed32 — only small values win with sint32.
+ */
+message CotGeoPoint {
+  /*
+   * Latitude delta from TAKPacketV2.latitude_i, in 1e-7 degree units.
+   * Add to the enclosing event's latitude_i to recover the absolute latitude.
+   */
+  sint32 lat_delta_i = 1;
+  /*
+   * Longitude delta from TAKPacketV2.longitude_i, in 1e-7 degree units.
+   */
+  sint32 lon_delta_i = 2;
+}
+
+/*
+ * User-drawn tactical graphic: circle, rectangle, polygon, polyline, freehand
+ * telestration, ranging circle, or bullseye.
+ *
+ * Covers CoT types u-d-c-c, u-d-r, u-d-f, u-d-f-m, u-d-p, u-r-b-c-c,
+ * u-r-b-bullseye. The shape's anchor position is carried on
+ * TAKPacketV2.latitude_i/longitude_i; polyline/polygon vertices are in the
+ * `vertices` repeated field as `CotGeoPoint` deltas from that anchor.
+ *
+ * Colors use the Team enum as a 14-color palette (see color encoding below)
+ * with a fixed32 exact-ARGB fallback for custom user-picked colors that
+ * don't map to a palette entry.
+ */
+message DrawnShape {
+  /*
+   * Shape kind discriminator. Drives receiver rendering and also controls
+   * which optional fields below are meaningful.
+   */
+  enum Kind {
+    /*
+     * Unspecified (do not use on the wire)
+     */
+    Kind_Unspecified = 0;
+    /*
+     * u-d-c-c: User-drawn circle (uses major/minor/angle, anchor = event point)
+     */
+    Kind_Circle = 1;
+    /*
+     * u-d-r: User-drawn rectangle (uses vertices = 4 corners)
+     */
+    Kind_Rectangle = 2;
+    /*
+     * u-d-f: User-drawn polyline (uses vertices, not closed)
+     */
+    Kind_Freeform = 3;
+    /*
+     * u-d-f-m: Freehand telestration / annotation (uses vertices, may be truncated)
+     */
+    Kind_Telestration = 4;
+    /*
+     * u-d-p: Closed polygon (uses vertices, implicitly closed)
+     */
+    Kind_Polygon = 5;
+    /*
+     * u-r-b-c-c: Ranging circle (major/minor/angle, stroke + optional fill)
+     */
+    Kind_RangingCircle = 6;
+    /*
+     * u-r-b-bullseye: Bullseye ring with range rings and bearing reference
+     */
+    Kind_Bullseye = 7;
+    /*
+     * u-d-c-e: Ellipse with distinct major/minor axes (same storage as
+     * Kind_Circle — uses major_cm/minor_cm/angle_deg — but receivers
+     * render it as a non-circular ellipse rather than a round circle).
+     */
+    Kind_Ellipse = 8;
+    /*
+     * u-d-v: 2D vehicle outline drawn on the map. Vertices carry the
+     * outline polygon; receivers draw it as a filled polygon.
+     */
+    Kind_Vehicle2D = 9;
+    /*
+     * u-d-v-m: 3D vehicle model reference. Same vertex polygon as
+     * Kind_Vehicle2D; receivers that support 3D rendering extrude it.
+     */
+    Kind_Vehicle3D = 10;
+  }
+  /*
+   * Explicit stroke/fill/both discriminator.
+   *
+   * ATAK's source XML distinguishes "stroke-only polyline" from "closed shape
+   * with both stroke and fill" by the presence of the <fillColor> element.
+   * Both states can hash to all-zero color fields, so we carry the signal
+   * explicitly. Parser sets this from (sawStrokeColor, sawFillColor) at the
+   * end of parse; builder uses it to decide which of <strokeColor> /
+   * <fillColor> to emit in the reconstructed XML.
+   */
+  enum StyleMode {
+    /*
+     * Unspecified — receiver infers from which color fields are non-zero.
+     */
+    StyleMode_Unspecified = 0;
+    /*
+     * Stroke only. No <fillColor> in the source XML. Used for polylines,
+     * ranging lines, bullseye rings.
+     */
+    StyleMode_StrokeOnly = 1;
+    /*
+     * Fill only. No <strokeColor> in the source XML. Rare but valid in
+     * ATAK (solid region with no outline).
+     */
+    StyleMode_FillOnly = 2;
+    /*
+     * Both stroke and fill present. Closed shapes: circle, rectangle,
+     * polygon, ranging circle.
+     */
+    StyleMode_StrokeAndFill = 3;
+  }
+  /*
+   * Shape kind (circle, rectangle, freeform, etc.)
+   */
+  Kind kind = 1;
+  /*
+   * Explicit stroke/fill/both discriminator. See StyleMode doc.
+   */
+  StyleMode style = 2;
+  /*
+   * Ellipse major radius in centimeters. 0 for non-ellipse kinds.
+   */
+  uint32 major_cm = 3;
+  /*
+   * Ellipse minor radius in centimeters. 0 for non-ellipse kinds.
+   */
+  uint32 minor_cm = 4;
+  /*
+   * Ellipse rotation angle in degrees. Valid values are 0..360 inclusive;
+   * 0 and 360 are equivalent rotations. In proto3, an unset uint32 reads
+   * as 0, so senders should emit 0 when the angle is unspecified.
+   */
+  uint32 angle_deg = 5;
+  /*
+   * Stroke color as a named palette entry from the Team enum. If
+   * Unspecifed_Color, the exact ARGB is carried in stroke_argb.
+   * Valid only when style is StrokeOnly or StrokeAndFill.
+   */
+  Team stroke_color = 6;
+  /*
+   * Stroke color as an exact 32-bit ARGB bit pattern. Always populated
+   * on the wire; readers MUST use this value when stroke_color ==
+   * Unspecifed_Color and MAY use it to recover the exact original bytes
+   * even when a palette entry is set.
+   */
+  fixed32 stroke_argb = 7;
+  /*
+   * Stroke weight in tenths of a unit (e.g. 30 = 3.0). Typical ATAK
+   * range 10..60.
+   */
+  uint32 stroke_weight_x10 = 8;
+  /*
+   * Fill color as a named palette entry. See stroke_color docs.
+   * Valid only when style is FillOnly or StrokeAndFill.
+   */
+  Team fill_color = 9;
+  /*
+   * Fill color exact ARGB fallback. See stroke_argb docs.
+   */
+  fixed32 fill_argb = 10;
+  /*
+   * Whether labels are rendered on this shape.
+   */
+  bool labels_on = 11;
+  /*
+   * Vertex list for polyline/polygon/rectangle shapes. Capped at 32 by
+   * the nanopb pool; senders MUST truncate longer inputs and set
+   * `truncated = true`.
+   */
+  repeated CotGeoPoint vertices = 12;
+  /*
+   * True if the sender truncated `vertices` to fit the pool.
+   */
+  bool truncated = 13;
+  // --- Bullseye-only fields. All ignored unless kind == Kind_Bullseye. ---
+  /*
+   * Bullseye distance in meters * 10 (e.g. 3285 = 328.5 m). 0 = unset.
+   */
+  uint32 bullseye_distance_dm = 14;
+  /*
+   * Bullseye bearing reference: 0 unset, 1 Magnetic, 2 True, 3 Grid.
+   */
+  uint32 bullseye_bearing_ref = 15;
+  /*
+   * Bullseye attribute bit flags:
+   *   bit 0: rangeRingVisible
+   *   bit 1: hasRangeRings
+   *   bit 2: edgeToCenter
+   *   bit 3: mils
+   */
+  uint32 bullseye_flags = 16;
+  /*
+   * Bullseye reference UID (anchor marker). Empty = anchor is self.
+   */
+  string bullseye_uid_ref = 17;
+}
+
+/*
+ * Fixed point of interest: spot marker, waypoint, checkpoint, 2525 symbol,
+ * or custom icon.
+ *
+ * Covers CoT types b-m-p-s-m, b-m-p-w, b-m-p-c, b-m-p-s-p-i, b-m-p-s-p-loc,
+ * plus a-u-G / a-f-G / a-h-G / a-n-G with iconset paths. The marker position
+ * is carried on TAKPacketV2.latitude_i/longitude_i; fields below carry only
+ * the marker-specific metadata.
+ */
+message Marker {
+  /*
+   * Marker kind. Used to pick sensible receiver defaults when the CoT type
+   * alone is ambiguous (e.g. a-u-G could be a 2525 symbol or a custom icon
+   * depending on the iconset path).
+   */
+  enum Kind {
+    /*
+     * Unspecified — fall back to TAKPacketV2.cot_type_id
+     */
+    Kind_Unspecified = 0;
+    /*
+     * b-m-p-s-m: Spot map marker
+     */
+    Kind_Spot = 1;
+    /*
+     * b-m-p-w: Route waypoint
+     */
+    Kind_Waypoint = 2;
+    /*
+     * b-m-p-c: Checkpoint
+     */
+    Kind_Checkpoint = 3;
+    /*
+     * b-m-p-s-p-i / b-m-p-s-p-loc: Self-position marker
+     */
+    Kind_SelfPosition = 4;
+    /*
+     * 2525B/C military symbol (iconsetpath = COT_MAPPING_2525B/...)
+     */
+    Kind_Symbol2525 = 5;
+    /*
+     * COT_MAPPING_SPOTMAP icon (e.g. colored dot)
+     */
+    Kind_SpotMap = 6;
+    /*
+     * Custom icon set (UUID/GroupName/filename.png)
+     */
+    Kind_CustomIcon = 7;
+    /*
+     * b-m-p-w-GOTO: Go To / bloodhound navigation waypoint.
+     */
+    Kind_GoToPoint = 8;
+    /*
+     * b-m-p-c-ip: Initial point (mission planning control point).
+     */
+    Kind_InitialPoint = 9;
+    /*
+     * b-m-p-c-cp: Contact point (mission planning control point).
+     */
+    Kind_ContactPoint = 10;
+    /*
+     * b-m-p-s-p-op: Observation post.
+     */
+    Kind_ObservationPost = 11;
+    /*
+     * b-i-x-i: Quick Pic geotagged image marker. iconset carries the
+     * image reference (local filename or remote URL); the image itself
+     * does not ride on the LoRa wire.
+     */
+    Kind_ImageMarker = 12;
+  }
+  /*
+   * Marker kind
+   */
+  Kind kind = 1;
+  /*
+   * Marker color as a named palette entry. If Unspecifed_Color, the exact
+   * ARGB is in color_argb.
+   */
+  Team color = 2;
+  /*
+   * Marker color exact ARGB bit pattern. Always populated on the wire.
+   */
+  fixed32 color_argb = 3;
+  /*
+   * Status readiness flag (ATAK <status readiness="true"/>).
+   */
+  bool readiness = 4;
+  /*
+   * Parent link UID (ATAK <link uid=... relation="p-p"/>). Empty = no parent.
+   * For spot/waypoint markers this is typically the producing TAK user's UID.
+   */
+  string parent_uid = 5;
+  /*
+   * Parent CoT type (e.g. "a-f-G-U-C"). Usually the parent TAK user's type.
+   */
+  string parent_type = 6;
+  /*
+   * Parent callsign (e.g. "HOPE").
+   */
+  string parent_callsign = 7;
+  /*
+   * Iconset path stored verbatim. ATAK emits three flavors:
+   *   Kind_Symbol2525    -> "COT_MAPPING_2525B/<cot-type-prefix>/<cot-type>"
+   *   Kind_SpotMap       -> "COT_MAPPING_SPOTMAP/<cot-type>/<argb>"
+   *   Kind_CustomIcon    -> "<UUID>/<GroupName>/<filename>.png"
+   * Stored end-to-end without prefix stripping; the ~19 bytes saved by
+   * stripping well-known prefixes are not worth the builder-side bug
+   * surface, and the dict compresses the repetition effectively.
+   */
+  string iconset = 8;
+}
+
+/*
+ * Range and bearing measurement line from the event anchor to a target point.
+ *
+ * Covers CoT type u-rb-a. The anchor position is on
+ * TAKPacketV2.latitude_i/longitude_i; the target endpoint is carried as a
+ * CotGeoPoint — same delta-from-anchor encoding used by DrawnShape.vertices
+ * so a self-anchored RAB (common case) encodes in zero bytes.
+ */
+message RangeAndBearing {
+  /*
+   * Target/anchor endpoint (delta-encoded from TAKPacketV2.latitude_i/longitude_i).
+   */
+  CotGeoPoint anchor = 1;
+  /*
+   * Anchor UID (from <link uid="anchor-1"/>). Empty = free-standing.
+   */
+  string anchor_uid = 2;
+  /*
+   * Range in centimeters (value * 100). Range 0..4294 km.
+   */
+  uint32 range_cm = 3;
+  /*
+   * Bearing in degrees * 100 (0..36000).
+   */
+  uint32 bearing_cdeg = 4;
+  /*
+   * Stroke color as a Team palette entry. See DrawnShape.stroke_color doc.
+   */
+  Team stroke_color = 5;
+  /*
+   * Stroke color exact ARGB fallback.
+   */
+  fixed32 stroke_argb = 6;
+  /*
+   * Stroke weight * 10 (e.g. 30 = 3.0).
+   */
+  uint32 stroke_weight_x10 = 7;
+}
+
+/*
+ * Named route consisting of ordered waypoints and control points.
+ *
+ * Covers CoT type b-m-r. The first waypoint's position is on
+ * TAKPacketV2.latitude_i/longitude_i; subsequent waypoints and checkpoints
+ * are in `links`. Link count is capped at 16 by the nanopb pool; senders
+ * MUST truncate longer routes and set `truncated = true`.
+ */
+message Route {
+  /*
+   * Travel method for the route.
+   */
+  enum Method {
+    /*
+     * Unspecified / unknown
+     */
+    Method_Unspecified = 0;
+    /*
+     * Driving / vehicle
+     */
+    Method_Driving = 1;
+    /*
+     * Walking / foot
+     */
+    Method_Walking = 2;
+    /*
+     * Flying
+     */
+    Method_Flying = 3;
+    /*
+     * Swimming (individual)
+     */
+    Method_Swimming = 4;
+    /*
+     * Watercraft (boat)
+     */
+    Method_Watercraft = 5;
+  }
+  /*
+   * Route direction (infil = ingress, exfil = egress).
+   */
+  enum Direction {
+    /*
+     * Unspecified
+     */
+    Direction_Unspecified = 0;
+    /*
+     * Infiltration (ingress)
+     */
+    Direction_Infil = 1;
+    /*
+     * Exfiltration (egress)
+     */
+    Direction_Exfil = 2;
+  }
+  /*
+   * Route waypoint or control point. Each link corresponds to one ATAK
+   * <link type=... point=...> entry inside the b-m-r event.
+   */
+  message Link {
+    /*
+     * Waypoint position (delta-encoded from TAKPacketV2.latitude_i/longitude_i).
+     */
+    CotGeoPoint point = 1;
+    /*
+     * Optional UID (empty = receiver derives).
+     */
+    string uid = 2;
+    /*
+     * Optional display callsign (e.g. "CP1"). Empty for unnamed control points.
+     */
+    string callsign = 3;
+    /*
+     * Link role: 0 = waypoint (b-m-p-w), 1 = checkpoint (b-m-p-c).
+     */
+    uint32 link_type = 4;
+  }
+  /*
+   * Travel method
+   */
+  Method method = 1;
+  /*
+   * Direction (infil/exfil)
+   */
+  Direction direction = 2;
+  /*
+   * Waypoint name prefix (e.g. "CP").
+   */
+  string prefix = 3;
+  /*
+   * Stroke weight * 10 (e.g. 30 = 3.0). 0 = default.
+   */
+  uint32 stroke_weight_x10 = 4;
+  /*
+   * Ordered list of route control points. Capped at 16.
+   */
+  repeated Link links = 5;
+  /*
+   * True if the sender truncated `links` to fit the pool.
+   */
+  bool truncated = 6;
+}
+
+/*
+ * 9-line MEDEVAC request (CoT type b-r-f-h-c).
+ *
+ * Mirrors the ATAK MedLine tool's <_medevac_> detail element. Every field
+ * is optional (proto3 default); senders omit lines they don't have. The
+ * envelope (TAKPacketV2.uid, cot_type_id=b-r-f-h-c, latitude_i/longitude_i,
+ * altitude, callsign) carries Line 1 (location) and Line 2 (callsign).
+ *
+ * All numeric fields are tight varints so a complete 9-line request fits
+ * in well under 100 bytes of proto on the wire.
+ */
+message CasevacReport {
+  /*
+   * Line 3: precedence / urgency.
+   */
+  enum Precedence {
+    Precedence_Unspecified = 0;
+    Precedence_Urgent = 1; // A - immediate, life-threatening
+    Precedence_UrgentSurgical = 2; // B - needs surgery
+    Precedence_Priority = 3; // C - within 4 hours
+    Precedence_Routine = 4; // D - within 24 hours
+    Precedence_Convenience = 5; // E - convenience
+  }
+  /*
+   * Line 7: HLZ marking method.
+   */
+  enum HlzMarking {
+    HlzMarking_Unspecified = 0;
+    HlzMarking_Panels = 1;
+    HlzMarking_PyroSignal = 2;
+    HlzMarking_Smoke = 3;
+    HlzMarking_None = 4;
+    HlzMarking_Other = 5;
+  }
+  /*
+   * Line 6: security situation at the pickup zone.
+   */
+  enum Security {
+    Security_Unspecified = 0;
+    Security_NoEnemy = 1; // N - no enemy activity
+    Security_PossibleEnemy = 2; // P - possible enemy
+    Security_EnemyInArea = 3; // E - enemy, approach with caution
+    Security_EnemyInArmedContact = 4; // X - armed escort required
+  }
+
+  /*
+   * Line 3: precedence / urgency.
+   */
+  Precedence precedence = 1;
+  /*
+   * Line 4: special equipment required, as a bitfield.
+   *   bit 0: none
+   *   bit 1: hoist
+   *   bit 2: extraction equipment
+   *   bit 3: ventilator
+   *   bit 4: blood
+   */
+  uint32 equipment_flags = 2;
+  /*
+   * Line 5: number of litter (stretcher-bound) patients.
+   */
+  uint32 litter_patients = 3;
+  /*
+   * Line 5: number of ambulatory (walking-wounded) patients.
+   */
+  uint32 ambulatory_patients = 4;
+  /*
+   * Line 6: security situation at the PZ.
+   */
+  Security security = 5;
+  /*
+   * Line 7: HLZ marking method.
+   */
+  HlzMarking hlz_marking = 6;
+  /*
+   * Line 7 supplementary: short free-text describing the zone marker
+   * (e.g. "Green smoke", "VS-17 panel west"). Capped tight in options.
+   */
+  string zone_marker = 7;
+  // --- Line 8: patient nationality counts ---
+  uint32 us_military = 8;
+  uint32 us_civilian = 9;
+  uint32 non_us_military = 10;
+  uint32 non_us_civilian = 11;
+  uint32 epw = 12; // enemy prisoner of war
+  uint32 child = 13;
+  /*
+   * Line 9: terrain and obstacles at the PZ, as a bitfield.
+   *   bit 0: slope
+   *   bit 1: rough
+   *   bit 2: loose
+   *   bit 3: trees
+   *   bit 4: wires
+   *   bit 5: other
+   */
+  uint32 terrain_flags = 14;
+  /*
+   * Line 2: radio frequency / callsign metadata (e.g. "38.90 Mhz" or
+   * "Victor 6"). Capped tight in options.
+   */
+  string frequency = 15;
+
+  // --- v2.x medline extensions (tags 16–33) --------------------------------
+  //
+  // Fields 16+ cost a 2-byte tag instead of 1 byte, but they're usually
+  // sparse so the on-wire delta is modest when most stay unset. A fully
+  // populated CASEVAC with 13 free-text fields + 2 ZMIST entries can run
+  // 200-400 bytes compressed, i.e. potentially over the 237 B LoRa MTU.
+  // Callers that hit the MTU on the `compressWithRemarksFallback` path
+  // SHOULD strip the tier-2 situational fields (tags 28-32 + terrain_other_detail)
+  // before dropping the packet entirely. See README "CASEVAC tier-2 stripping".
+
+  /*
+   * Short title / MEDEVAC identifier (e.g. "EAGLE.15.181230"). Usually the
+   * same as the envelope callsign but ATAK sometimes carries a distinct
+   * ops-number here.
+   */
+  string title = 16;
+  /*
+   * Primary medline free-text — the single most clinically important line
+   * on a MEDLINE form (e.g. "2 urgent litter patients, smoke on approach").
+   * MUST be preserved under MTU pressure as long as any casevac is sent.
+   */
+  string medline_remarks = 17;
+
+  /*
+   * Line 3 (newer ATAK format): patient counts by precedence level.
+   * Coexists with the enum-style `precedence` field (tag 1) — older ATAK
+   * emits a single enum, newer ATAK emits these counts, and both can be
+   * set simultaneously. Senders populate whichever style(s) the source
+   * XML had; receivers prefer counts when non-zero.
+   */
+  uint32 urgent_count = 18;
+  uint32 urgent_surgical_count = 19;
+  uint32 priority_count = 20;
+  uint32 routine_count = 21;
+  uint32 convenience_count = 22;
+
+  /*
+   * Line 4 supplementary: free-text description of non-standard equipment
+   * (e.g. "Blood warmer"). Pairs with the `equipment_flags` bitfield.
+   */
+  string equipment_detail = 23;
+  /*
+   * Line 1 override: MGRS grid when distinct from the event anchor point
+   * (e.g. "34T CQ 12345 67890"). Event lat/lon/hae still carries the
+   * numeric location; this field preserves the exact MGRS string the
+   * medic entered.
+   */
+  string zone_protected_coord = 24;
+  /*
+   * Line 9 supplementary: slope direction (e.g. "N", "NE", "SSW") when
+   * `terrain_flags` bit 0 (slope) is set.
+   */
+  string terrain_slope_dir = 25;
+  /*
+   * Line 9 supplementary: free-text description of "other" terrain hazards
+   * (e.g. "Loose debris on west edge") when `terrain_flags` bit 5 (other)
+   * is set. Tier-2 strippable under MTU pressure.
+   */
+  string terrain_other_detail = 26;
+  /*
+   * Line 7 supplementary: how the zone is being marked right now
+   * (e.g. "Orange smoke", "VS-17 panel"). Complements the structured
+   * `hlz_marking` enum with a specific human-readable description.
+   */
+  string marked_by = 27;
+
+  // --- Tier-2 situational awareness (stripped first under MTU pressure) ---
+  // These fields are free-text context that helps the receiver plan the
+  // approach but aren't strictly required to evacuate the patient.
+
+  /*
+   * Nearby obstacles on the approach (e.g. "Power lines north of HLZ").
+   */
+  string obstacles = 28;
+  /*
+   * Wind direction and speed (e.g. "270 at 12 kts").
+   */
+  string winds_are_from = 29;
+  /*
+   * Friendly forces posture near the pickup zone
+   * (e.g. "Squad east of HLZ").
+   */
+  string friendlies = 30;
+  /*
+   * Known or suspected enemy positions near the pickup zone
+   * (e.g. "Possible enemy on south ridge").
+   */
+  string enemy = 31;
+  /*
+   * Free-text description of the HLZ itself
+   * (e.g. "Primary HLZ is soccer field").
+   */
+  string hlz_remarks = 32;
+
+  /*
+   * Per-patient clinical records. Each entry is one patient's ZMIST card
+   * (Zap number / Mechanism / Injuries / Signs / Treatment). Repeatable —
+   * a mass-casualty event can carry 1-6 entries in practice, limited by
+   * the 237 B LoRa MTU.
+   */
+  repeated ZMistEntry zmist = 33;
+}
+
+/*
+ * Per-patient clinical summary record — one entry per patient in a CASEVAC.
+ * Maps directly to ATAK's <zMist> child element inside <zMistsMap>.
+ * All fields are optional free-text; senders populate what they have.
+ */
+message ZMistEntry {
+  /*
+   * Patient identifier / sequence label (e.g. "ZMIST-1", "ZMIST-2").
+   */
+  string title = 1;
+  /*
+   * Zap number — unique patient tracking ID (often a terse code like
+   * "Gunshot" or a serial).
+   */
+  string z = 2;
+  /*
+   * Mechanism of injury (e.g. "Penetrating trauma", "Blast injury").
+   */
+  string m = 3;
+  /*
+   * Injuries observed (e.g. "Left thigh", "Concussion").
+   */
+  string i = 4;
+  /*
+   * Signs / vital stats (e.g. "Stable", "Priority", "BP 110/70").
+   */
+  string s = 5;
+  /*
+   * Treatment given (e.g. "Tourniquet 1810Z", "O2 administered").
+   */
+  string t = 6;
+}
+
+/*
+ * Emergency alert / 911 beacon (CoT types b-a-o-tbl, b-a-o-pan, b-a-o-opn,
+ * b-a-o-can, b-a-o-c, b-a-g).
+ *
+ * Small, high-priority structured record. The CoT type string is still set
+ * on cot_type_id so receivers that ignore payload_variant can still display
+ * the alert from the enum alone; the typed fields let modern receivers show
+ * the authoring unit and handle cancel-referencing without XML parsing.
+ */
+message EmergencyAlert {
+  enum Type {
+    Type_Unspecified = 0;
+    Type_Alert911 = 1; // b-a-o-tbl
+    Type_RingTheBell = 2; // b-a-o-pan
+    Type_InContact = 3; // b-a-o-opn
+    Type_GeoFenceBreached = 4; // b-a-g
+    Type_Custom = 5; // b-a-o-c
+    Type_Cancel = 6; // b-a-o-can
+  }
+  /*
+   * Alert discriminator.
+   */
+  Type type = 1;
+  /*
+   * UID of the unit that raised the alert. Often the same as
+   * TAKPacketV2.uid but can be a parent device uid when a tracker raises
+   * an alert on behalf of a dismount.
+   */
+  string authoring_uid = 2;
+  /*
+   * For Type_Cancel: the uid of the alert being cancelled. Empty for
+   * non-cancel alert types.
+   */
+  string cancel_reference_uid = 3;
+}
+
+/*
+ * Task / engage request (CoT type t-s).
+ *
+ * Mirrors ATAK's TaskCotReceiver / CotTaskBuilder workflow. The envelope
+ * carries the task's originating uid (implicit requester), position, and
+ * creation time; the fields below carry structured metadata the raw-detail
+ * fallback currently loses.
+ *
+ * Fields are deliberately lean — this variant is closer to the MTU ceiling
+ * than the others, so every string is capped in options.
+ */
+message TaskRequest {
+  enum Priority {
+    Priority_Unspecified = 0;
+    Priority_Low = 1;
+    Priority_Normal = 2;
+    Priority_High = 3;
+    Priority_Critical = 4;
+  }
+  enum Status {
+    Status_Unspecified = 0;
+    Status_Pending = 1; // assigned, not yet acknowledged
+    Status_Acknowledged = 2; // assignee has seen it
+    Status_InProgress = 3; // assignee is working it
+    Status_Completed = 4; // task done
+    Status_Cancelled = 5; // cancelled before completion
+  }
+
+  /*
+   * Short tag for the task category (e.g. "engage", "observe", "recon",
+   * "rescue"). Free text on the wire so ATAK-specific task taxonomies
+   * don't need proto coordination; capped tight in options.
+   */
+  string task_type = 1;
+  /*
+   * UID of the target / map item being tasked.
+   */
+  string target_uid = 2;
+  /*
+   * UID of the assigned unit. Empty = unassigned / broadcast task.
+   */
+  string assignee_uid = 3;
+  Priority priority = 4;
+  Status status = 5;
+  /*
+   * Optional short note (reason, constraints, grid reference). Capped
+   * tight in options to keep the worst-case under the LoRa MTU.
+   */
+  string note = 6;
+}
+
+/*
+ * Weather annotation from <environment> CoT detail element.
+ *
+ * Attaches to any TAKPacketV2 regardless of payload_variant — an Aircraft,
+ * PLI, or Marker can all carry observed conditions at the emitting station.
+ * ATAK-CIV ships an XSD for <environment> but no dedicated handler, so the
+ * element round-trips through the generic detail pipeline; this message
+ * promotes it to a first-class structured field.
+ *
+ * Target wire cost: ~6-8 bytes compressed with a fully populated instance.
+ *
+ * Named `TAKEnvironment` (not just `Environment`) because the bare name
+ * collides with `SwiftUI.Environment` — every SwiftUI view in a consuming
+ * iOS app uses the `@Environment` property wrapper, and importing the
+ * generated proto module would make `Environment` ambiguous in every one
+ * of those files. The `TAK` prefix matches the convention used by the
+ * outer `TAKPacketV2` wrapper and is unambiguous across all target
+ * languages (Swift, Kotlin, Python, TypeScript, C#).
+ */
+message TAKEnvironment {
+  /*
+   * Temperature in deci-degrees Celsius. 225 = 22.5°C.
+   * Range covers -50°C to +50°C (-500 to +500) which spans every realistic
+   * outdoor TAK deployment. sint32 because negative temps are common in
+   * cold-weather ops.
+   */
+  sint32 temperature_c_x10 = 1;
+  /*
+   * Wind direction in whole degrees, 0-359. "Direction FROM" per
+   * meteorological convention (matches CoT / ATAK).
+   */
+  uint32 wind_direction_deg = 2;
+  /*
+   * Wind speed in cm/s. Matches the unit of TAKPacketV2.speed for
+   * consistency. 1200 = 12.00 m/s = ~27 mph.
+   */
+  uint32 wind_speed_cm_s = 3;
+}
+
+/*
+ * Sensor field-of-view cone from <sensor> CoT detail element.
+ *
+ * Encodes the 8 geometry attributes that ATAK-CIV's SensorDetailHandler
+ * reads from the wire; drops the 9 visual-styling attributes that are
+ * receiver-side render hints (fovAlpha, fovRed/Green/Blue, strokeColor,
+ * strokeWeight, displayMagneticReference, hideFov, fovLabels, rangeLines).
+ * The receiving ATAK client restores those from its own defaults, same as
+ * every other CoT carried over Meshtastic today.
+ *
+ * Attaches to any TAKPacketV2 — a PLI with a sensor on the operator's head,
+ * an Aircraft with a FLIR turret, a Marker dropped on a UAV.
+ * Target wire cost: ~7-14 bytes compressed (dominated by model string).
+ */
+message SensorFov {
+  /*
+   * Coarse sensor category, inferred from `model` on parse when the source
+   * XML doesn't label it. Receivers that render differently per sensor
+   * class (thermal overlay vs daylight cone) use this.
+   */
+  enum SensorType {
+    SensorType_Unspecified = 0;
+    SensorType_Camera = 1; // daylight / general optical
+    SensorType_Thermal = 2; // FLIR, thermal imager
+    SensorType_Laser = 3; // rangefinder, LRF, designator
+    SensorType_Nvg = 4; // night vision goggles
+    SensorType_Rf = 5; // radio/radar direction-finding
+    SensorType_Other = 6;
+  }
+
+  SensorType type = 1;
+  /*
+   * Azimuth in whole degrees, 0-359. "Pointing direction" of the cone axis,
+   * measured clockwise from true north. Whole degrees match ATAK-CIV's
+   * SensorDetailHandler default (270°) and save varint bytes over centi-deg.
+   */
+  uint32 azimuth_deg = 2;
+  /*
+   * Maximum range of the cone in meters.
+   * Optional — if unset, receivers should use the ATAK-CIV default of 100m.
+   */
+  optional uint32 range_m = 3;
+  /*
+   * Horizontal field of view in whole degrees (cone's angular width).
+   * ATAK-CIV default is 45°.
+   */
+  uint32 fov_horizontal_deg = 4;
+  /*
+   * Vertical field of view in whole degrees. ATAK-CIV default is 45°.
+   * Optional — a value of 0 means "not set / use horizontal FOV".
+   */
+  uint32 fov_vertical_deg = 5;
+  /*
+   * Elevation angle in whole degrees. Positive = up, negative = down.
+   * Range -90 to +90. sint32 for varint efficiency on small negatives.
+   */
+  sint32 elevation_deg = 6;
+  /*
+   * Roll (camera tilt) in whole degrees, -180 to +180.
+   * Optional — use 0 if the sensor doesn't track roll.
+   */
+  sint32 roll_deg = 7;
+  /*
+   * Free-form device model identifier, e.g. "FLIR-Boson-640", "SEEK".
+   * Optional — empty string means "unknown model" (ATAK-CIV default).
+   */
+  string model = 8;
+}
+
+/*
+ * ATAK v2 packet with expanded CoT field support and zstd dictionary compression.
+ * Sent on ATAK_PLUGIN_V2 port. The wire payload is:
+ *   [1 byte flags][zstd-compressed TAKPacketV2 protobuf]
+ * Flags byte: bits 0-5 = dictionary ID, bits 6-7 = reserved.
+ */
+message TAKPacketV2 {
+  /*
+   * Well-known CoT event type enum.
+   * Use CotType_Other with cot_type_str for unknown types.
+   */
+  CotType cot_type_id = 1;
+  /*
+   * How the coordinates were generated
+   */
+  CotHow how = 2;
+  /*
+   * Callsign
+   */
+  string callsign = 3;
+  /*
+   * Team color assignment
+   */
+  Team team = 4;
+  /*
+   * Role of the group member
+   */
+  MemberRole role = 5;
+  /*
+   * Latitude, multiply by 1e-7 to get degrees in floating point
+   */
+  sfixed32 latitude_i = 6;
+  /*
+   * Longitude, multiply by 1e-7 to get degrees in floating point
+   */
+  sfixed32 longitude_i = 7;
+  /*
+   * Altitude in meters (HAE)
+   */
+  sint32 altitude = 8;
+  /*
+   * Speed in cm/s
+   */
+  uint32 speed = 9;
+  /*
+   * Course in degrees * 100 (0-36000)
+   */
+  uint32 course = 10;
+  /*
+   * Battery level 0-100
+   */
+  uint32 battery = 11;
+  /*
+   * Geopoint source
+   */
+  GeoPointSource geo_src = 12;
+  /*
+   * Altitude source
+   */
+  GeoPointSource alt_src = 13;
+  /*
+   * Device UID (UUID string or device ID like "ANDROID-xxxx")
+   */
+  string uid = 14;
+  /*
+   * Device callsign
+   */
+  string device_callsign = 15;
+  /*
+   * Stale time as seconds offset from event time
+   */
+  uint32 stale_seconds = 16;
+  /*
+   * TAK client version string
+   */
+  string tak_version = 17;
+  /*
+   * TAK device model
+   */
+  string tak_device = 18;
+  /*
+   * TAK platform (ATAK-CIV, WebTAK, etc.)
+   */
+  string tak_platform = 19;
+  /*
+   * TAK OS version
+   */
+  string tak_os = 20;
+  /*
+   * Connection endpoint
+   */
+  string endpoint = 21;
+  /*
+   * Phone number
+   */
+  string phone = 22;
+  /*
+   * CoT event type string, only populated when cot_type_id is CotType_Other
+   */
+  string cot_type_str = 23;
+  /*
+   * Optional remarks / free-text annotation from the <remarks> element.
+   * Populated for non-GeoChat payload types (shapes, markers, routes, etc.)
+   * when the original CoT event carried non-empty remarks text.
+   * GeoChat messages carry their text in GeoChat.message instead.
+   * Empty string (proto3 default) means no remarks were present.
+   */
+  string remarks = 24;
+
+  // --- Sensor / environment annotations ----------------------------------
+  //
+  // Both fields are OPTIONAL and attach to any payload_variant. They
+  // describe observed conditions at the emitting station — a PLI with
+  // environment data, an Aircraft with a sensor cone, a Marker with both.
+  // Absent by default; presence is signaled by the message being non-null.
+
+  /*
+   * Observed weather conditions (temperature, wind). From <environment>.
+   * Type is `TAKEnvironment`, not `Environment`, to avoid colliding with
+   * SwiftUI's `@Environment` property wrapper in iOS consumers.
+   */
+  optional TAKEnvironment environment = 25;
+  /*
+   * Sensor field-of-view cone (camera, FLIR, laser, etc.). From <sensor>.
+   */
+  optional SensorFov sensor_fov = 26;
+
+  reserved 27, 28, 29;
+  // Tags 27, 28, 29 reserved for future top-level annotations before the
+  // payload_variant oneof resumes at 30.
+
+  /*
+   * The payload of the packet
+   */
+  oneof payload_variant {
+    /*
+     * Position report (true = PLI, no extra fields beyond the common ones above)
+     */
+    bool pli = 30;
+    /*
+     * ATAK GeoChat message
+     */
+    GeoChat chat = 31;
+    /*
+     * Aircraft track data (ADS-B, military air)
+     */
+    AircraftTrack aircraft = 32;
+    /*
+     * Generic CoT detail XML for unmapped types. Kept as a fallback for CoT
+     * types not yet promoted to a typed variant; drawings, markers, ranging
+     * tools, and routes have dedicated variants below and should not land here.
+     */
+    bytes raw_detail = 33;
+    /*
+     * User-drawn tactical graphic: circle, rectangle, polygon, polyline,
+     * telestration, ranging circle, or bullseye. See DrawnShape.
+     */
+    DrawnShape shape = 34;
+    /*
+     * Fixed point of interest: spot marker, waypoint, checkpoint, 2525
+     * symbol, or custom icon. See Marker.
+     */
+    Marker marker = 35;
+    /*
+     * Range and bearing measurement line. See RangeAndBearing.
+     */
+    RangeAndBearing rab = 36;
+    /*
+     * Named route with ordered waypoints and control points. See Route.
+     */
+    Route route = 37;
+    /*
+     * 9-line MEDEVAC request. See CasevacReport.
+     */
+    CasevacReport casevac = 38;
+    /*
+     * Emergency beacon / 911 alert. See EmergencyAlert.
+     */
+    EmergencyAlert emergency = 39;
+    /*
+     * Task / engage request. See TaskRequest.
+     */
+    TaskRequest task = 40;
+  }
 }

--- a/app/src/main/proto/meshtastic/channel.proto
+++ b/app/src/main/proto/meshtastic/channel.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+/* trunk-ignore(buf-lint/PACKAGE_DIRECTORY_MATCH) */
 package meshtastic;
 
 option csharp_namespace = "Meshtastic.Protobufs";
@@ -98,10 +99,10 @@ message ModuleSettings {
   uint32 position_precision = 1;
 
   /*
-   * Controls whether or not the phone / clients should mute the current channel
+   * Controls whether or not the client / device should mute the current channel
    * Useful for noisy public channels you don't necessarily want to disable
    */
-  bool is_client_muted = 2;
+  bool is_muted = 2;
 }
 
 /*

--- a/app/src/main/proto/meshtastic/config.proto
+++ b/app/src/main/proto/meshtastic/config.proto
@@ -48,8 +48,9 @@ message Config {
        * Description: Infrastructure node for extending network coverage by relaying messages with minimal overhead. Not visible in Nodes list.
        * Technical Details: Mesh packets will simply be rebroadcasted over this node. Nodes configured with this role will not originate NodeInfo, Position, Telemetry
        *   or any other packet type. They will simply rebroadcast any mesh packets on the same frequency, channel num, spread factor, and coding rate.
+       * Deprecated in v2.7.11 because it creates "holes" in the mesh rebroadcast chain.
        */
-      REPEATER = 4;
+      REPEATER = 4 [deprecated = true];
 
       /*
        * Description: Broadcasts GPS position packets as priority.
@@ -108,6 +109,14 @@ message Config {
        *    consuming hops.
        */
       ROUTER_LATE = 11;
+
+      /*
+       * Description: Treats packets from or to favorited nodes as ROUTER_LATE, and all other packets as CLIENT.
+       * Technical Details: Used for stronger attic/roof nodes to distribute messages more widely
+       *    from weaker, indoor, or less-well-positioned nodes. Recommended for users with multiple nodes
+       *    where one CLIENT_BASE acts as a more powerful base station, such as an attic/roof node.
+       */
+      CLIENT_BASE = 12;
     }
 
     /*
@@ -151,6 +160,43 @@ message Config {
     }
 
     /*
+     * Defines buzzer behavior for audio feedback
+     */
+    enum BuzzerMode {
+      /*
+       * Default behavior.
+       * Buzzer is enabled for all audio feedback including button presses and alerts.
+       */
+      ALL_ENABLED = 0;
+
+      /*
+       * Disabled.
+       * All buzzer audio feedback is disabled.
+       */
+      DISABLED = 1;
+
+      /*
+       * Notifications Only.
+       * Buzzer is enabled only for notifications and alerts, but not for button presses.
+       * External notification config determines the specifics of the notification behavior.
+       */
+      NOTIFICATIONS_ONLY = 2;
+
+      /*
+       * Non-notification system buzzer tones only.
+       * Buzzer is enabled only for non-notification tones such as button presses, startup, shutdown, but not for alerts.
+       */
+      SYSTEM_ONLY = 3;
+
+      /*
+       * Direct Message notifications only.
+       * Buzzer is enabled only for direct messages and alerts, but not for button presses.
+       * External notification config determines the specifics of the notification behavior.
+       */
+      DIRECT_MSG_ONLY = 4;
+    }
+
+    /*
      * Sets the role of node
      */
     Role role = 1;
@@ -159,7 +205,7 @@ message Config {
      * Disabling this will disable the SerialConsole by not initilizing the StreamAPI
      * Moved to SecurityConfig
      */
-    bool serial_enabled = 2[deprecated = true];
+    bool serial_enabled = 2 [deprecated = true];
 
     /*
      * For boards without a hard wired button, this is the pin number that will be used
@@ -194,7 +240,7 @@ message Config {
      * Clients should then limit available configuration and administrative options inside the user interface
      * Moved to SecurityConfig
      */
-    bool is_managed = 9[deprecated = true];
+    bool is_managed = 9 [deprecated = true];
 
     /*
      * Disables the triple-press of user button to enable or disable GPS
@@ -210,6 +256,12 @@ message Config {
      * If true, disable the default blinking LED (LED_PIN) behavior on the device
      */
     bool led_heartbeat_disabled = 12;
+
+    /*
+     * Controls buzzer behavior for audio feedback
+     * Defaults to ENABLED
+     */
+    BuzzerMode buzzer_mode = 13;
   }
 
   /*
@@ -434,7 +486,7 @@ message Config {
      * If non-zero, we want powermon log outputs.  With the particular (bitfield) sources enabled.
      * Note: we picked an ID of 32 so that lower more efficient IDs can be used for more frequently used options.
      */
-     uint64 powermon_enables = 32;
+    uint64 powermon_enables = 32;
   }
 
   /*
@@ -522,6 +574,11 @@ message Config {
     uint32 enabled_protocols = 10;
 
     /*
+     * Enable/Disable ipv6 support
+     */
+    bool ipv6_enabled = 11;
+
+    /*
      * Available flags auxiliary network protocols
      */
     enum ProtocolFlags {
@@ -542,45 +599,10 @@ message Config {
    */
   message DisplayConfig {
     /*
-     * How the GPS coordinates are displayed on the OLED screen.
+     * Deprecated in 2.7.4: Unused
      */
-    enum GpsCoordinateFormat {
-      /*
-       * GPS coordinates are displayed in the normal decimal degrees format:
-       * DD.DDDDDD DDD.DDDDDD
-       */
-      DEC = 0;
-
-      /*
-       * GPS coordinates are displayed in the degrees minutes seconds format:
-       * DD°MM'SS"C DDD°MM'SS"C, where C is the compass point representing the locations quadrant
-       */
-      DMS = 1;
-
-      /*
-       * Universal Transverse Mercator format:
-       * ZZB EEEEEE NNNNNNN, where Z is zone, B is band, E is easting, N is northing
-       */
-      UTM = 2;
-
-      /*
-       * Military Grid Reference System format:
-       * ZZB CD EEEEE NNNNN, where Z is zone, B is band, C is the east 100k square, D is the north 100k square,
-       * E is easting, N is northing
-       */
-      MGRS = 3;
-
-      /*
-       * Open Location Code (aka Plus Codes).
-       */
-      OLC = 4;
-
-      /*
-       * Ordnance Survey Grid Reference (the National Grid System of the UK).
-       * Format: AB EEEEE NNNNN, where A is the east 100k square, B is the north 100k square,
-       * E is the easting, N is the northing
-       */
-      OSGR = 5;
+    enum DeprecatedGpsCoordinateFormat {
+      UNUSED = 0;
     }
 
     /*
@@ -603,24 +625,29 @@ message Config {
      */
     enum OledType {
       /*
-       * Default / Auto
+       * Default / Autodetect
        */
       OLED_AUTO = 0;
 
       /*
-       * Default / Auto
+       * Default / Autodetect
        */
       OLED_SSD1306 = 1;
 
       /*
-       * Default / Auto
+       * Default / Autodetect
        */
       OLED_SH1106 = 2;
 
       /*
-       * Can not be auto detected but set by proto. Used for 128x128 screens
+       * Can not be auto detected but set by proto. Used for 128x64 screens
        */
       OLED_SH1107 = 3;
+
+      /*
+       * Can not be auto detected but set by proto. Used for 128x128 screens
+       */
+      OLED_SH1107_128_128 = 4;
     }
 
     /*
@@ -630,9 +657,10 @@ message Config {
     uint32 screen_on_secs = 1;
 
     /*
+     * Deprecated in 2.7.4: Unused
      * How the GPS coordinates are formatted on the OLED screen.
      */
-    GpsCoordinateFormat gps_format = 2;
+    DeprecatedGpsCoordinateFormat gps_format = 2 [deprecated = true];
 
     /*
      * Automatically toggles to the next page on the screen like a carousel, based the specified interval in seconds.
@@ -644,7 +672,7 @@ message Config {
      * If this is set, the displayed compass will always point north. if unset, the old behaviour
      * (top of display is heading direction) is used.
      */
-    bool compass_north_top = 4;
+    bool compass_north_top = 4 [deprecated = true];
 
     /*
      * Flip screen vertically, for cases that mount the screen upside down
@@ -737,7 +765,7 @@ message Config {
        * Rotate the compass by 270 degrees and invert.
        */
       DEGREES_270_INVERTED = 7;
-      }
+    }
 
     /*
      * Indicates how to rotate or invert the compass output to accurate display on the display.
@@ -749,6 +777,17 @@ message Config {
      * If true, the device will display the time in 12-hour format on screen.
      */
     bool use_12h_clock = 12;
+
+    /*
+     * If false (default), the device will use short names for various display screens.
+     * If true, node names will show in long format
+     */
+    bool use_long_node_name = 13;
+
+    /*
+     * If true, the device will display message bubbles on screen.
+     */
+    bool enable_message_bubbles = 14;
   }
 
   /*
@@ -865,6 +904,57 @@ message Config {
        * Philippines 915mhz
        */
       PH_915 = 21;
+
+      /*
+       * Australia / New Zealand 433MHz
+       */
+      ANZ_433 = 22;
+
+      /*
+       * Kazakhstan 433MHz
+       */
+      KZ_433 = 23;
+
+      /*
+       * Kazakhstan 863MHz
+       */
+      KZ_863 = 24;
+
+      /*
+       * Nepal 865MHz
+       */
+      NP_865 = 25;
+
+      /*
+       * Brazil 902MHz
+       */
+      BR_902 = 26;
+
+      /*
+       * ITU Region 1 Amateur Radio 2m band (144-146 MHz)
+       */
+      ITU1_2M = 27;
+
+      /*
+       * ITU Region 2 / 3 Amateur Radio 2m band (144-148 MHz)
+       */
+      ITU23_2M = 28;
+
+      /*
+       * EU 866MHz band (Band no. 47b of 2006/771/EC and subsequent amendments) for Non-specific short-range devices (SRD)
+       */
+      EU_866 = 29;
+
+      /*
+       * EU 874MHz and 917MHz bands (Band no. 1 and 4 of 2022/172/EC and subsequent amendments) for Non-specific short-range devices (SRD)
+       */
+      EU_874 = 30;
+      EU_917 = 31;
+
+      /*
+       * EU 868MHz band, with narrow presets
+       */
+      EU_N_868 = 32;
     }
 
     /*
@@ -879,8 +969,9 @@ message Config {
 
       /*
        * Long Range - Slow
+       * Deprecated in 2.7: Unpopular slow preset.
        */
-      LONG_SLOW = 1;
+      LONG_SLOW = 1 [deprecated = true];
 
       /*
        * Very Long Range - Slow
@@ -919,6 +1010,58 @@ message Config {
        * It is not legal to use in all regions due to this wider bandwidth.
        */
       SHORT_TURBO = 8;
+
+      /*
+       * Long Range - Turbo
+       * This preset performs similarly to LongFast, but with 500Khz bandwidth.
+       */
+      LONG_TURBO = 9;
+
+      /*
+       * Lite Fast
+       * Medium range preset optimized for EU 866MHz SRD band with 125kHz bandwidth.
+       * Comparable link budget to MEDIUM_FAST but compliant with Band no. 47b of 2006/771/EC.
+       */
+      LITE_FAST = 10;
+
+      /*
+       * Lite Slow
+       * Medium-to-moderate range preset optimized for EU 866MHz SRD band with 125kHz bandwidth.
+       * Comparable link budget to LONG_FAST but compliant with Band no. 47b of 2006/771/EC.
+       */
+      LITE_SLOW = 11;
+
+      /*
+       * Narrow Fast
+       * Medium-to-moderate range preset optimized for EU 868MHz band with 62.5kHz bandwidth.
+       * Comparable link budget to SHORT_SLOW, but with half the data rate.
+       * Intended to avoid interference with other devices.
+       */
+      NARROW_FAST = 12;
+
+      /*
+       * Narrow Slow
+       * Moderate range preset optimized for EU 868MHz band with 62.5kHz bandwidth.
+       * Comparable link budget and data rate to LONG_FAST.
+       */
+      NARROW_SLOW = 13;
+    }
+
+    enum FEM_LNA_Mode {
+      /*
+       * FEM_LNA is present but disabled
+       */
+      DISABLED = 0;
+
+      /*
+       * FEM_LNA is present and enabled
+       */
+      ENABLED = 1;
+
+      /*
+       * FEM_LNA is not present on the device
+       */
+      NOT_PRESENT = 2;
     }
 
     /*
@@ -1041,6 +1184,16 @@ message Config {
      * Sets the ok_to_mqtt bit on outgoing packets
      */
     bool config_ok_to_mqtt = 105;
+
+    /*
+     * Set where LORA FEM is enabled, disabled, or not present
+     */
+    FEM_LNA_Mode fem_lna_mode = 106;
+
+    /*
+     * Don't use radiolib to initialize the radio, instead listen for a serialHal connection
+     */
+    bool serial_hal_only = 107;
   }
 
   message BluetoothConfig {
@@ -1078,17 +1231,16 @@ message Config {
   }
 
   message SecurityConfig {
-
-  /*
-   * The public key of the user's device.
-   * Sent out to other nodes on the mesh to allow them to compute a shared secret key.
-   */
+    /*
+     * The public key of the user's device.
+     * Sent out to other nodes on the mesh to allow them to compute a shared secret key.
+     */
     bytes public_key = 1;
 
-  /*
-   * The private key of the device.
-   * Used to create a shared key with a remote device.
-   */
+    /*
+     * The private key of the device.
+     * Used to create a shared key with a remote device.
+     */
     bytes private_key = 2;
 
     /*

--- a/app/src/main/proto/meshtastic/device_ui.proto
+++ b/app/src/main/proto/meshtastic/device_ui.proto
@@ -71,8 +71,77 @@ message DeviceUIConfig {
    * Map related data
    */
   Map map_data = 15;
-}
 
+  /*
+   * Compass mode
+   */
+  CompassMode compass_mode = 16;
+
+  /*
+   * RGB color for BaseUI
+   * 0xRRGGBB format, e.g. 0xFF0000 for red
+   */
+  uint32 screen_rgb_color = 17;
+
+  /*
+   * Clockface analog style
+   * true for analog clockface, false for digital clockface
+   */
+  bool is_clockface_analog = 18;
+
+  /*
+   * How the GPS coordinates are formatted on the OLED screen.
+   */
+  GpsCoordinateFormat gps_format = 19;
+
+  /*
+   * How the GPS coordinates are displayed on the OLED screen.
+   */
+  enum GpsCoordinateFormat {
+    /*
+     * GPS coordinates are displayed in the normal decimal degrees format:
+     * DD.DDDDDD DDD.DDDDDD
+     */
+    DEC = 0;
+
+    /*
+     * GPS coordinates are displayed in the degrees minutes seconds format:
+     * DD°MM'SS"C DDD°MM'SS"C, where C is the compass point representing the locations quadrant
+     */
+    DMS = 1;
+
+    /*
+     * Universal Transverse Mercator format:
+     * ZZB EEEEEE NNNNNNN, where Z is zone, B is band, E is easting, N is northing
+     */
+    UTM = 2;
+
+    /*
+     * Military Grid Reference System format:
+     * ZZB CD EEEEE NNNNN, where Z is zone, B is band, C is the east 100k square, D is the north 100k square,
+     * E is easting, N is northing
+     */
+    MGRS = 3;
+
+    /*
+     * Open Location Code (aka Plus Codes).
+     */
+    OLC = 4;
+
+    /*
+     * Ordnance Survey Grid Reference (the National Grid System of the UK).
+     * Format: AB EEEEE NNNNN, where A is the east 100k square, B is the north 100k square,
+     * E is the easting, N is the northing
+     */
+    OSGR = 5;
+
+    /*
+     * Maidenhead Locator System
+     * Described here: https://en.wikipedia.org/wiki/Maidenhead_Locator_System
+     */
+    MLS = 6;
+  }
+}
 
 message NodeFilter {
   /*
@@ -109,7 +178,6 @@ message NodeFilter {
    * Filter based on channel
    */
   int32 channel = 7;
-
 }
 
 message NodeHighlight {
@@ -137,7 +205,6 @@ message NodeHighlight {
    * Highlight nodes by matching name string
    */
   string node_name = 5;
-
 }
 
 message GeoPoint {
@@ -146,14 +213,14 @@ message GeoPoint {
    */
   int32 zoom = 1;
 
-   /*
-    * Coordinate: latitude
-    */
+  /*
+   * Coordinate: latitude
+   */
   int32 latitude = 2;
 
-   /*
-    * Coordinate: longitude
-    */
+  /*
+   * Coordinate: longitude
+   */
   int32 longitude = 3;
 }
 
@@ -172,6 +239,23 @@ message Map {
    * Map scroll follows GPS
    */
   bool follow_gps = 3;
+}
+
+enum CompassMode {
+  /*
+   * Compass with dynamic ring and heading
+   */
+  DYNAMIC = 0;
+
+  /*
+   * Compass with fixed ring and heading
+   */
+  FIXED_RING = 1;
+
+  /*
+   * Compass with heading and freeze option
+   */
+  FREEZE_HEADING = 2;
 }
 
 enum Theme {
@@ -278,7 +362,22 @@ enum Language {
    */
   UKRAINIAN = 16;
 
-   /*
+  /*
+   * Bulgarian
+   */
+  BULGARIAN = 17;
+
+  /*
+   * Czech
+   */
+  CZECH = 18;
+
+  /*
+   * Danish
+   */
+  DANISH = 19;
+
+  /*
    * Simplified Chinese (experimental)
    */
   SIMPLIFIED_CHINESE = 30;
@@ -287,4 +386,4 @@ enum Language {
    * Traditional Chinese (experimental)
    */
   TRADITIONAL_CHINESE = 31;
-  }
+}

--- a/app/src/main/proto/meshtastic/localonly.proto
+++ b/app/src/main/proto/meshtastic/localonly.proto
@@ -132,6 +132,21 @@ message LocalModuleConfig {
   ModuleConfig.PaxcounterConfig paxcounter = 14;
 
   /*
+   * StatusMessage Config
+   */
+  ModuleConfig.StatusMessageConfig statusmessage = 15;
+
+  /*
+   * The part of the config that is specific to the Traffic Management module
+   */
+  ModuleConfig.TrafficManagementConfig traffic_management = 16;
+
+  /*
+   * TAK Config
+   */
+  ModuleConfig.TAKConfig tak = 17;
+
+  /*
    * A version integer used to invalidate old save files when we make
    * incompatible changes This integer is set at build time and is private to
    * NodeDB.cpp in the device code.

--- a/app/src/main/proto/meshtastic/mesh.proto
+++ b/app/src/main/proto/meshtastic/mesh.proto
@@ -4,11 +4,11 @@ package meshtastic;
 
 import "meshtastic/channel.proto";
 import "meshtastic/config.proto";
+import "meshtastic/device_ui.proto";
 import "meshtastic/module_config.proto";
 import "meshtastic/portnums.proto";
 import "meshtastic/telemetry.proto";
 import "meshtastic/xmodem.proto";
-import "meshtastic/device_ui.proto";
 
 option csharp_namespace = "Meshtastic.Protobufs";
 option go_package = "github.com/meshtastic/go/generated";
@@ -388,9 +388,9 @@ enum HardwareModel {
   LORA_RELAY_V1 = 32;
 
   /*
-   * TODO: REPLACE
+   * T-Echo Plus device from LilyGo
    */
-  NRF52840DK = 33;
+  T_ECHO_PLUS = 33;
 
   /*
    * TODO: REPLACE
@@ -564,22 +564,22 @@ enum HardwareModel {
    */
   HELTEC_CAPSULE_SENSOR_V3 = 65;
 
-   /*
+  /*
    * Heltec Vision Master T190 with ESP32-S3 CPU, and a 1.90 inch TFT display
    */
   HELTEC_VISION_MASTER_T190 = 66;
 
-   /*
+  /*
    * Heltec Vision Master E213 with ESP32-S3 CPU, and a 2.13 inch E-Ink display
    */
   HELTEC_VISION_MASTER_E213 = 67;
 
-   /*
+  /*
    * Heltec Vision Master E290 with ESP32-S3 CPU, and a 2.9 inch E-Ink display
    */
   HELTEC_VISION_MASTER_E290 = 68;
 
-   /*
+  /*
    * Heltec Mesh Node T114 board with nRF52840 CPU, and a 1.14 inch TFT display, Ultimate low-power design,
    * specifically adapted for the Meshtatic project
    */
@@ -590,7 +590,7 @@ enum HardwareModel {
    */
   SENSECAP_INDICATOR = 70;
 
-   /*
+  /*
    * Seeed studio T1000-E tracker card. NRF52840 w/ LR1110 radio, GPS, button, buzzer, and sensors.
    */
   TRACKER_T1000_E = 71;
@@ -611,7 +611,7 @@ enum HardwareModel {
    */
   RADIOMASTER_900_BANDIT = 74;
 
-   /*
+  /*
    * Minewsemi ME25LS01 (ME25LE01_V1.0). NRF52840 w/ LR1110 radio, buttons and leds and pins.
    */
   ME25LS01_4Y10TD = 75;
@@ -640,7 +640,7 @@ enum HardwareModel {
   /* Seeed XIAO S3 DK*/
   SEEED_XIAO_S3 = 81;
 
-   /*
+  /*
    * Nordic nRF52840+Semtech SX1262 LoRa BLE Combo Module. nRF52840+SX1262 MS24SF1
    */
   MS24SF1 = 82;
@@ -680,7 +680,7 @@ enum HardwareModel {
    * Seeed XIAO nRF52840 + Wio SX1262 kit
    */
   XIAO_NRF52_KIT = 88;
-  
+
   /*
    * Elecrow ThinkNode M1 & M2
    * https://www.elecrow.com/wiki/ThinkNode-M1_Transceiver_Device(Meshtastic)_Power_By_nRF52840.html
@@ -693,12 +693,216 @@ enum HardwareModel {
    * Lilygo T-ETH-Elite
    */
   T_ETH_ELITE = 91;
-  
+
   /*
    * Heltec HRI-3621 industrial probe
    */
   HELTEC_SENSOR_HUB = 92;
 
+  /*
+   * Muzi Works Muzi-Base device
+   */
+  MUZI_BASE = 93;
+
+  /*
+   * Heltec Magnetic Power Bank with Meshtastic compatible
+   */
+  HELTEC_MESH_POCKET = 94;
+
+  /*
+   * Seeed Solar Node
+   */
+  SEEED_SOLAR_NODE = 95;
+
+  /*
+   * NomadStar Meteor Pro https://nomadstar.ch/
+   */
+  NOMADSTAR_METEOR_PRO = 96;
+
+  /*
+   * Elecrow CrowPanel Advance models, ESP32-S3 and TFT with SX1262 radio plugin
+   */
+  CROWPANEL = 97;
+
+  /*
+   * Lilygo LINK32 board with sensors
+   */
+  LINK_32 = 98;
+
+  /*
+   * Seeed Tracker L1
+   */
+  SEEED_WIO_TRACKER_L1 = 99;
+
+  /*
+   * Seeed Tracker L1 EINK driver
+   */
+  SEEED_WIO_TRACKER_L1_EINK = 100;
+
+  /*
+   * Muzi Works R1 Neo
+   */
+  MUZI_R1_NEO = 101;
+
+  /*
+   * Lilygo T-Deck Pro
+   */
+  T_DECK_PRO = 102;
+
+  /*
+   * Lilygo TLora Pager
+   */
+  T_LORA_PAGER = 103;
+
+  /*
+   * M5Stack Reserved
+   */
+  M5STACK_RESERVED = 104; // 0x68
+
+  /*
+   * RAKwireless WisMesh Tag
+   */
+  WISMESH_TAG = 105;
+
+  /*
+   * RAKwireless WisBlock Core RAK3312 https://docs.rakwireless.com/product-categories/wisduo/rak3112-module/overview/
+   */
+  RAK3312 = 106;
+
+  /*
+   * Elecrow ThinkNode M5 https://www.elecrow.com/wiki/ThinkNode_M5_Meshtastic_LoRa_Signal_Transceiver_ESP32-S3.html
+   */
+  THINKNODE_M5 = 107;
+
+  /*
+   * MeshSolar is an integrated power management and communication solution designed for outdoor low-power devices.
+   * https://heltec.org/project/meshsolar/
+   */
+  HELTEC_MESH_SOLAR = 108;
+
+  /*
+   * Lilygo T-Echo Lite
+   */
+  T_ECHO_LITE = 109;
+
+  /*
+   * New Heltec LoRA32 with ESP32-S3 CPU
+   */
+  HELTEC_V4 = 110;
+
+  /*
+   * M5Stack C6L
+   */
+  M5STACK_C6L = 111;
+
+  /*
+   * M5Stack Cardputer Adv
+   */
+  M5STACK_CARDPUTER_ADV = 112;
+
+  /*
+   * ESP32S3 main controller with GPS and TFT screen.
+   */
+  HELTEC_WIRELESS_TRACKER_V2 = 113;
+
+  /*
+   * LilyGo T-Watch Ultra
+   */
+  T_WATCH_ULTRA = 114;
+
+  /*
+   * Elecrow ThinkNode M3
+   */
+  THINKNODE_M3 = 115;
+
+  /*
+   * RAK WISMESH_TAP_V2 with ESP32-S3 CPU
+   */
+  WISMESH_TAP_V2 = 116;
+
+  /*
+   * RAK3401
+   */
+  RAK3401 = 117;
+
+  /*
+   * RAK6421 Hat+
+   */
+  RAK6421 = 118;
+
+  /*
+   * Elecrow ThinkNode M4
+   */
+  THINKNODE_M4 = 119;
+
+  /*
+   * Elecrow ThinkNode M6
+   */
+  THINKNODE_M6 = 120;
+
+  /*
+   * Elecrow Meshstick 1262
+   */
+  MESHSTICK_1262 = 121;
+
+  /*
+   * LilyGo T-Beam 1W
+   */
+  TBEAM_1_WATT = 122;
+
+  /*
+   * LilyGo T5 S3 ePaper Pro (V1 and V2)
+   */
+  T5_S3_EPAPER_PRO = 123;
+
+  /*
+   * LilyGo T-Beam BPF (144-148Mhz)
+   */
+  TBEAM_BPF = 124;
+
+  /*
+   * LilyGo T-Mini E-paper S3 Kit
+   */
+  MINI_EPAPER_S3 = 125;
+
+  /*
+   * LilyGo T-Display S3 Pro LR1121
+   */
+  TDISPLAY_S3_PRO = 126;
+
+  /*
+   * Heltec Mesh Node T096 board features an nRF52840 CPU and a TFT screen.
+   */
+  HELTEC_MESH_NODE_T096 = 127;
+
+  /*
+   * Seeed studio T1000-E Pro tracker card. NRF52840 w/ LR2021 radio,
+   * GPS, button, buzzer, and sensors.
+   */
+  TRACKER_T1000_E_PRO = 128;
+
+  /*
+   * Elecrow ThinkNode M7, M8 and M9
+   */
+  THINKNODE_M7 = 129;
+  THINKNODE_M8 = 130;
+  THINKNODE_M9 = 131;
+
+  /*
+   * The Heltec-V4-R8 uses an ESP32S3R8 chip, plus an SX1262.
+   */
+  HELTEC_V4_R8 = 132;
+
+  /*
+   * The HELTEC_MESH_NODE_T1 uses an NRF52840 chip, plus an SX1262.
+   */
+  HELTEC_MESH_NODE_T1 = 133;
+
+  /*
+   * B&Q Consulting Station G3: TBD
+
+   */
+  STATION_G3 = 134;
   /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.
@@ -781,6 +985,11 @@ message User {
    * This is sent out to other nodes on the mesh to allow them to compute a shared secret key.
    */
   bytes public_key = 8;
+
+  /*
+   * Whether or not the node can be messaged
+   */
+  optional bool is_unmessagable = 9;
 }
 
 /*
@@ -898,6 +1107,18 @@ message Routing {
      * Admin packet sent using PKC, but not from a public key on the admin key list
      */
     ADMIN_PUBLIC_KEY_UNAUTHORIZED = 37;
+
+    /*
+     * Airtime fairness rate limit exceeded for a packet
+     * This typically enforced per portnum and is used to prevent a single node from monopolizing airtime
+     */
+    RATE_LIMIT_EXCEEDED = 38;
+
+    /*
+     * PKI encryption failed, due to no public key for the remote node
+     * This is different from PKI_UNKNOWN_PUBKEY which indicates a failure upon receiving a packet
+     */
+    PKI_SEND_FAIL_PUBLIC_KEY = 39;
   }
 
   oneof variant {
@@ -982,6 +1203,197 @@ message Data {
 }
 
 /*
+ * The actual over-the-mesh message doing KeyVerification
+ */
+message KeyVerification {
+  /*
+   * random value Selected by the requesting node
+   */
+  uint64 nonce = 1;
+
+  /*
+   * The final authoritative hash, only to be sent by NodeA at the end of the handshake
+   */
+  bytes hash1 = 2;
+
+  /*
+   * The intermediary hash (actually derived from hash1),
+   * sent from NodeB to NodeA in response to the initial message.
+   */
+  bytes hash2 = 3;
+}
+
+/*
+ * The actual over-the-mesh message doing store and forward++
+ */
+message StoreForwardPlusPlus {
+  /*
+   * Enum of message types
+   */
+  enum SFPP_message_type {
+    /*
+     * Send an announcement of the canonical tip of a chain
+     */
+    CANON_ANNOUNCE = 0;
+
+    /*
+     * Query whether a specific link is on the chain
+     */
+    CHAIN_QUERY = 1;
+
+    /*
+     * Request the next link in the chain
+     */
+    LINK_REQUEST = 3;
+
+    /*
+     * Provide a link to add to the chain
+     */
+    LINK_PROVIDE = 4;
+
+    /*
+     * If we must fragment, send the first half
+     */
+    LINK_PROVIDE_FIRSTHALF = 5;
+
+    /*
+     * If we must fragment, send the second half
+     */
+    LINK_PROVIDE_SECONDHALF = 6;
+  }
+
+  /*
+   * Which message type is this
+   */
+  SFPP_message_type sfpp_message_type = 1;
+
+  /*
+   * The hash of the specific message
+   */
+  bytes message_hash = 2;
+
+  /*
+   * The hash of a link on a chain
+   */
+  bytes commit_hash = 3;
+
+  /*
+   * the root hash of a chain
+   */
+  bytes root_hash = 4;
+
+  /*
+   * The encrypted bytes from a message
+   */
+  bytes message = 5;
+
+  /*
+   * Message ID of the contained message
+   */
+  uint32 encapsulated_id = 6;
+
+  /*
+   * Destination of the contained message
+   */
+  uint32 encapsulated_to = 7;
+
+  /*
+   * Sender of the contained message
+   */
+  uint32 encapsulated_from = 8;
+
+  /*
+   * The receive time of the message in question
+   */
+  uint32 encapsulated_rxtime = 9;
+
+  /*
+   * Used in a LINK_REQUEST to specify the message X spots back from head
+   */
+  uint32 chain_count = 10;
+}
+
+/*
+ * The actual over-the-mesh message doing RemoteShell
+ */
+message RemoteShell {
+  /*
+   * Frame op code for PTY session control and stream transport.
+   *
+   * Values 1-63 are client->server requests.
+   * Values 64-127 are server->client responses/events.
+   */
+  enum OpCode {
+    OP_UNSET = 0;
+
+    // Client -> server
+    OPEN = 1;
+    INPUT = 2;
+    RESIZE = 3;
+    CLOSE = 4;
+    PING = 5;
+    ACK = 6;
+
+    // Server -> client
+    OPEN_OK = 64;
+    OUTPUT = 65;
+    CLOSED = 66;
+    ERROR = 67;
+    PONG = 68;
+  }
+
+  /*
+   * Structured frame operation.
+   */
+  OpCode op = 1;
+
+  /*
+   * Logical PTY session identifier.
+   */
+  uint32 session_id = 2;
+
+  /*
+   * Monotonic sequence number for this frame.
+   */
+  uint32 seq = 3;
+
+  /*
+   * Cumulative ack sequence number.
+   */
+  uint32 ack_seq = 4;
+
+  /*
+   * Opaque bytes payload for INPUT/OUTPUT/ERROR and other frame bodies.
+   */
+  bytes payload = 5;
+
+  /*
+   * Terminal size columns used for OPEN/RESIZE signaling.
+   */
+  uint32 cols = 6;
+
+  /*
+   * Terminal size rows used for OPEN/RESIZE signaling.
+   */
+  uint32 rows = 7;
+
+  /*
+   * Bit flags for protocol extensions.
+   */
+  uint32 flags = 8;
+
+  /*
+   * The last sequence number TX'd.
+   */
+  uint32 last_tx_seq = 9;
+
+  /*
+   * The last sequence number RX'd.
+   */
+  uint32 last_rx_seq = 10;
+}
+
+/*
  * Waypoint message, used to share arbitrary locations across the mesh
  */
 message Waypoint {
@@ -1025,6 +1437,13 @@ message Waypoint {
    * Designator icon for the waypoint in the form of a unicode emoji
    */
   fixed32 icon = 8;
+}
+
+/*
+ * Message for node status
+ */
+message StatusMessage {
+  string status = 1;
 }
 
 /*
@@ -1160,6 +1579,51 @@ message MeshPacket {
   }
 
   /*
+   * Enum to identify which transport mechanism this packet arrived over
+   */
+  enum TransportMechanism {
+    /*
+     * The default case is that the node generated a packet itself
+     */
+    TRANSPORT_INTERNAL = 0;
+
+    /*
+     * Arrived via the primary LoRa radio
+     */
+    TRANSPORT_LORA = 1;
+
+    /*
+     * Arrived via a secondary LoRa radio
+     */
+    TRANSPORT_LORA_ALT1 = 2;
+
+    /*
+     * Arrived via a tertiary LoRa radio
+     */
+    TRANSPORT_LORA_ALT2 = 3;
+
+    /*
+     * Arrived via a quaternary LoRa radio
+     */
+    TRANSPORT_LORA_ALT3 = 4;
+
+    /*
+     * Arrived via an MQTT connection
+     */
+    TRANSPORT_MQTT = 5;
+
+    /*
+     * Arrived via Multicast UDP
+     */
+    TRANSPORT_MULTICAST_UDP = 6;
+
+    /*
+     * Arrived via API connection
+     */
+    TRANSPORT_API = 7;
+  }
+
+  /*
    * The sending node number.
    * Note: Our crypto implementation uses this field as well.
    * See [crypto](/docs/overview/encryption) for details.
@@ -1168,6 +1632,10 @@ message MeshPacket {
 
   /*
    * The (immediate) destination for this packet
+   * If the value is 4,294,967,295 (maximum value of an unsigned 32bit integer), this indicates that the packet was
+   * not destined for a specific node, but for a channel as indicated by the value of `channel` below.
+   * If the value is another, this indicates that the packet was destined for a specific
+   * node (i.e. a kind of "Direct Message" to this node) and not broadcast on a channel.
    */
   fixed32 to = 2;
 
@@ -1306,6 +1774,11 @@ message MeshPacket {
    * Set by the firmware internally, clients are not supposed to set this.
    */
   uint32 tx_after = 20;
+
+  /*
+   * Indicates which transport mechanism this packet arrived over
+   */
+  TransportMechanism transport_mechanism = 21;
 }
 
 /*
@@ -1429,6 +1902,19 @@ message NodeInfo {
    * Persists between NodeDB internal clean ups
    */
   bool is_ignored = 11;
+
+  /*
+   * True if node public key has been verified.
+   * Persists between NodeDB internal clean ups
+   * LSB 0 of the bitfield
+   */
+  bool is_key_manually_verified = 12;
+
+  /*
+   * True if node has been muted
+   * Persistes between NodeDB internal clean ups
+   */
+  bool is_muted = 13;
 }
 
 /*
@@ -1514,6 +2000,47 @@ enum CriticalErrorCode {
 }
 
 /*
+ * Enum to indicate to clients whether this firmware is a special firmware build, like an event.
+ * The first 16 values are reserved for non-event special firmwares, like the Smart Citizen use case.
+ */
+enum FirmwareEdition {
+  /*
+   * Vanilla firmware
+   */
+  VANILLA = 0;
+
+  /*
+   * Firmware for use in the Smart Citizen environmental monitoring network
+   */
+  SMART_CITIZEN = 1;
+
+  /*
+   * Open Sauce, the maker conference held yearly in CA
+   */
+  OPEN_SAUCE = 16;
+
+  /*
+   * DEFCON, the yearly hacker conference
+   */
+  DEFCON = 17;
+
+  /*
+   * Burning Man, the yearly hippie gathering in the desert
+   */
+  BURNING_MAN = 18;
+
+  /*
+   * Hamvention, the Dayton amateur radio convention
+   */
+  HAMVENTION = 19;
+
+  /*
+   * Placeholder for DIY and unofficial events
+   */
+  DIY_EDITION = 127;
+}
+
+/*
  * Unique local debugging info for this node
  * Note: we don't include position or the user info, because that will come in the
  * Sent to the phone in response to WantNodes.
@@ -1546,6 +2073,17 @@ message MyNodeInfo {
    * The PlatformIO environment used to build this firmware
    */
   string pio_env = 13;
+
+  /*
+   * The indicator for whether this device is running event firmware and which
+   */
+  FirmwareEdition firmware_edition = 14;
+
+  /*
+   * The number of nodes in the nodedb.
+   * This is used by the phone to know how many NodeInfo packets to expect on want_config
+   */
+  uint32 nodedb_count = 15;
 }
 
 /*
@@ -1735,7 +2273,93 @@ message FromRadio {
      * Persistent data for device-ui
      */
     DeviceUIConfig deviceuiConfig = 17;
+
+    /*
+     * Lockdown state notification for hardened firmware builds.
+     * Sent post-config (so unauthorized clients learn they must
+     * provision/unlock) and after each LockdownAuth admin command
+     * to report success or failure. Replaces the earlier scheme of
+     * encoding state as magic-string prefixes inside ClientNotification.
+     */
+    LockdownStatus lockdown_status = 18;
   }
+}
+
+/*
+ * Lockdown state report from firmware to client (for hardened builds
+ * with MESHTASTIC_LOCKDOWN). Sent immediately after config_complete_id
+ * to inform a freshly-connected unauthorized client what it must do,
+ * and again in response to each LockdownAuth admin command.
+ */
+message LockdownStatus {
+  enum State {
+    /* Default; should not be sent. */
+    STATE_UNSPECIFIED = 0;
+
+    /*
+     * No passphrase has ever been provisioned on this device.
+     * Client should prompt the operator to set one.
+     */
+    NEEDS_PROVISION = 1;
+
+    /*
+     * Storage is locked or this client has not authenticated yet.
+     * lock_reason carries a machine-readable detail string.
+     * Client should present (or auto-replay) a passphrase via
+     * AdminMessage.lockdown_auth.
+     */
+    LOCKED = 2;
+
+    /*
+     * Passphrase accepted; client is now authorized for this connection.
+     * boots_remaining and valid_until_epoch describe the active session
+     * token's TTL.
+     */
+    UNLOCKED = 3;
+
+    /*
+     * Passphrase rejected. backoff_seconds is non-zero when rate-limited.
+     */
+    UNLOCK_FAILED = 4;
+  }
+
+  /* Current lockdown state being reported. */
+  State state = 1;
+
+  /*
+   * For LOCKED: machine-readable reason. Known values:
+   *   "needs_auth"        — storage already unlocked, client must auth
+   *   "token_missing"     — no boot token on flash
+   *   "token_expired"     — boot token wall-clock TTL elapsed
+   *   "token_boots_zero"  — boot token boot-count TTL exhausted
+   *   "token_hmac_fail"   — token tampered or wrong device
+   *   "token_dek_fail"    — token DEK decrypt failed
+   *   "token_wrong_size"  — token file corrupted
+   *   "token_bad_magic"   — token file corrupted
+   *   "not_provisioned"   — should generally use NEEDS_PROVISION state instead
+   * Other values may be added; clients should treat unknown values as
+   * "locked, ask for passphrase".
+   */
+  string lock_reason = 2;
+
+  /*
+   * For UNLOCKED: remaining boots on the issued session token.
+   * Decrements by 1 on each subsequent boot.
+   */
+  uint32 boots_remaining = 3;
+
+  /*
+   * For UNLOCKED: wall-clock expiry of the issued session token,
+   * absolute Unix-epoch seconds. 0 = no time limit.
+   */
+  uint32 valid_until_epoch = 4;
+
+  /*
+   * For UNLOCK_FAILED: seconds the client must wait before another
+   * passphrase attempt will be accepted. 0 = wrong passphrase, no
+   * backoff (immediate retry allowed but advisable to prompt user).
+   */
+  uint32 backoff_seconds = 5;
 }
 
 /*
@@ -1763,7 +2387,33 @@ message ClientNotification {
    * The message body of the notification
    */
   string message = 4;
+
+  oneof payload_variant {
+    KeyVerificationNumberInform key_verification_number_inform = 11;
+    KeyVerificationNumberRequest key_verification_number_request = 12;
+    KeyVerificationFinal key_verification_final = 13;
+    DuplicatedPublicKey duplicated_public_key = 14;
+    LowEntropyKey low_entropy_key = 15;
+  }
 }
+
+message KeyVerificationNumberInform {
+  uint64 nonce = 1;
+  string remote_longname = 2;
+  uint32 security_number = 3;
+}
+message KeyVerificationNumberRequest {
+  uint64 nonce = 1;
+  string remote_longname = 2;
+}
+message KeyVerificationFinal {
+  uint64 nonce = 1;
+  string remote_longname = 2;
+  bool isSender = 3;
+  string verification_characters = 4;
+}
+message DuplicatedPublicKey {}
+message LowEntropyKey {}
 
 /*
  * Individual File info for the device
@@ -2038,7 +2688,7 @@ enum ExcludedModules {
    */
   PAXCOUNTER_CONFIG = 0x1000;
 
-  /* 
+  /*
    * Bluetooth config (not technically a module, but used to indicate bluetooth capabilities)
    */
   BLUETOOTH_CONFIG = 0x2000;
@@ -2053,7 +2703,12 @@ enum ExcludedModules {
  * A heartbeat message is sent to the node from the client to keep the connection alive.
  * This is currently only needed to keep serial connections alive, but can be used by any PhoneAPI.
  */
-message Heartbeat {}
+message Heartbeat {
+  /*
+   * The nonce of the heartbeat message
+   */
+  uint32 nonce = 1;
+}
 
 /*
  * RemoteHardwarePins associated with a node
@@ -2096,7 +2751,7 @@ message ChunkedPayload {
  * Wrapper message for broken repeated oneof support
  */
 message resend_chunks {
-    repeated uint32 chunks = 1;
+  repeated uint32 chunks = 1;
 }
 
 /*

--- a/app/src/main/proto/meshtastic/module_config.proto
+++ b/app/src/main/proto/meshtastic/module_config.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package meshtastic;
 
+import "meshtastic/atak.proto";
+
 option csharp_namespace = "Meshtastic.Protobufs";
 option go_package = "github.com/meshtastic/go/generated";
 option java_outer_classname = "ModuleConfigProtos";
@@ -95,6 +97,11 @@ message ModuleConfig {
      * Bits of precision for the location sent (default of 32 is full precision).
      */
     uint32 position_precision = 2;
+
+    /*
+     * Whether we have opted-in to report our location to the map
+     */
+    bool should_report_location = 3;
   }
 
   /*
@@ -143,7 +150,6 @@ message ModuleConfig {
    * Detection Sensor Module Config
    */
   message DetectionSensorConfig {
-
     enum TriggerType {
       // Event is triggered if pin is low
       LOGIC_LOW = 0;
@@ -289,7 +295,82 @@ message ModuleConfig {
      * BLE RSSI threshold. Defaults to -80
      */
     int32 ble_threshold = 4;
+  }
 
+  /*
+   * Config for the Traffic Management module.
+   * Provides packet inspection and traffic shaping to help reduce channel utilization
+   */
+  message TrafficManagementConfig {
+    /*
+     * Master enable for traffic management module
+     */
+    bool enabled = 1;
+
+    /*
+     * Enable position deduplication to drop redundant position broadcasts
+     */
+    bool position_dedup_enabled = 2;
+
+    /*
+     * Number of bits of precision for position deduplication (0-32)
+     */
+    uint32 position_precision_bits = 3;
+
+    /*
+     * Minimum interval in seconds between position updates from the same node
+     */
+    uint32 position_min_interval_secs = 4;
+
+    /*
+     * Enable direct response to NodeInfo requests from local cache
+     */
+    bool nodeinfo_direct_response = 5;
+
+    /*
+     * Minimum hop distance from requestor before responding to NodeInfo requests
+     */
+    uint32 nodeinfo_direct_response_max_hops = 6;
+
+    /*
+     * Enable per-node rate limiting to throttle chatty nodes
+     */
+    bool rate_limit_enabled = 7;
+
+    /*
+     * Time window in seconds for rate limiting calculations
+     */
+    uint32 rate_limit_window_secs = 8;
+
+    /*
+     * Maximum packets allowed per node within the rate limit window
+     */
+    uint32 rate_limit_max_packets = 9;
+
+    /*
+     * Enable dropping of unknown/undecryptable packets per rate_limit_window_secs
+     */
+    bool drop_unknown_enabled = 10;
+
+    /*
+     * Number of unknown packets before dropping from a node
+     */
+    uint32 unknown_packet_threshold = 11;
+
+    /*
+     * Set hop_limit to 0 for relayed telemetry broadcasts (own packets unaffected)
+     */
+    bool exhaust_hop_telemetry = 12;
+
+    /*
+     * Set hop_limit to 0 for relayed position broadcasts (own packets unaffected)
+     */
+    bool exhaust_hop_position = 13;
+
+    /*
+     * Preserve hop_limit for router-to-router traffic
+     */
+    bool router_preserve_hops = 14;
   }
 
   /*
@@ -331,6 +412,15 @@ message ModuleConfig {
       CALTOPO = 5;
       // Ecowitt WS85 weather station
       WS85 = 6;
+      // VE.Direct is a serial protocol used by Victron Energy products
+      // https://beta.ivc.no/wiki/index.php/Victron_VE_Direct_DIY_Cable
+      VE_DIRECT = 7;
+      // Used to configure and view some parameters of MeshSolar.
+      // https://heltec.org/project/meshsolar/
+      MS_CONFIG = 8;
+      // Logs mesh traffic to the serial pins, ideal for logging via openLog or similar.
+      LOG = 9; // includes other packets
+      LOGTEXT = 10; // only text (channel & DM)
     }
 
     /*
@@ -521,6 +611,12 @@ message ModuleConfig {
      * ESP32 Only
      */
     bool save = 3;
+
+    /*
+     * Bool indicating that the node should cleanup / destroy it's RangeTest.csv file.
+     * ESP32 Only
+     */
+    bool clear_on_reboot = 4;
   }
 
   /*
@@ -600,6 +696,17 @@ message ModuleConfig {
      * Enable/Disable the health telemetry module on-device display
      */
     bool health_screen_enabled = 13;
+
+    /*
+     * Enable/Disable the device telemetry module to send metrics to the mesh
+     * Note: We will still send telemtry to the connected phone / client every minute over the API
+     */
+    bool device_telemetry_enabled = 14;
+
+    /*
+     * Enable/Disable the air quality telemetry measurement module on-device display
+     */
+    bool air_quality_screen_enabled = 15;
   }
 
   /*
@@ -694,13 +801,13 @@ message ModuleConfig {
     /*
      * Enable/disable CannedMessageModule.
      */
-    bool enabled = 9;
+    bool enabled = 9 [deprecated = true];
 
     /*
      * Input event origin accepted by the canned message module.
      * Can be e.g. "rotEnc1", "upDownEnc1", "scanAndSelect", "cardkb", "serialkb", or keyword "_any"
      */
-    string allow_input_source = 10;
+    string allow_input_source = 10 [deprecated = true];
 
     /*
      * CannedMessageModule also sends a bell character with the messages.
@@ -738,6 +845,16 @@ message ModuleConfig {
      * Sets the blue LED level. Values are 0-255.
      */
     uint32 blue = 5;
+  }
+
+  /*
+   * StatusMessage config - Allows setting a status message for a node to periodically rebroadcast
+   */
+  message StatusMessageConfig {
+    /*
+     * The actual status string
+     */
+    string node_status = 1;
   }
 
   /*
@@ -808,6 +925,37 @@ message ModuleConfig {
      * TODO: REPLACE
      */
     PaxcounterConfig paxcounter = 13;
+
+    /*
+     * TODO: REPLACE
+     */
+    StatusMessageConfig statusmessage = 14;
+
+    /*
+     * Traffic management module config for mesh network optimization
+     */
+    TrafficManagementConfig traffic_management = 15;
+
+    /*
+     * TAK team/role configuration for TAK_TRACKER
+     */
+    TAKConfig tak = 16;
+  }
+
+  /*
+   * TAK team/role configuration
+   */
+  message TAKConfig {
+    /*
+     * Team color.
+     * Default Unspecifed_Color -> firmware uses Cyan
+     */
+    Team team = 1;
+    /*
+     * Member role.
+     * Default Unspecifed -> firmware uses TeamMember
+     */
+    MemberRole role = 2;
   }
 }
 

--- a/app/src/main/proto/meshtastic/portnums.proto
+++ b/app/src/main/proto/meshtastic/portnums.proto
@@ -111,6 +111,16 @@ enum PortNum {
   ALERT_APP = 11;
 
   /*
+   * Module/port for handling key verification requests.
+   */
+  KEY_VERIFICATION_APP = 12;
+
+  /*
+   * Module/port for handling primitive remote shell access.
+   */
+  REMOTE_SHELL_APP = 13;
+
+  /*
    * Provides a 'ping' service that replies to any packet it receives.
    * Also serves as a small example module.
    * ENCODING: ASCII Plaintext
@@ -128,6 +138,22 @@ enum PortNum {
    * ENCODING: protobuf
    */
   PAXCOUNTER_APP = 34;
+
+  /*
+   * Store and Forward++ module included in the firmware
+   * ENCODING: protobuf
+   * This module is specifically for Native Linux nodes, and provides a Git-style
+   * chain of messages.
+   */
+  STORE_FORWARD_PLUSPLUS_APP = 35;
+
+  /*
+   * Node Status module
+   * ENCODING: protobuf
+   * This module allows setting an extra string of status for a node.
+   * Broadcasts on change and on a timer, possibly once a day.
+   */
+  NODE_STATUS_APP = 36;
 
   /*
    * Provides a hardware serial interface to send and receive from the Meshtastic network.
@@ -207,10 +233,37 @@ enum PortNum {
   POWERSTRESS_APP = 74;
 
   /*
+   * LoraWAN Payload Transport
+   * ENCODING: compact binary LoRaWAN uplink (10-byte RF metadata + PHY payload) - see LoRaWANBridgeModule
+   */
+  LORAWAN_BRIDGE = 75;
+
+  /*
    * Reticulum Network Stack Tunnel App
    * ENCODING: Fragmented RNS Packet. Handled by Meshtastic RNS interface
    */
   RETICULUM_TUNNEL_APP = 76;
+
+  /*
+   * App for transporting Cayenne Low Power Payload, popular for LoRaWAN sensor nodes. Offers ability to send
+   * arbitrary telemetry over meshtastic that is not covered by telemetry.proto
+   * ENCODING: CayenneLLP
+   */
+  CAYENNE_APP = 77;
+
+  /*
+   * ATAK Plugin V2
+   * Portnum for payloads from the official Meshtastic ATAK plugin using
+   * TAKPacketV2 with zstd dictionary compression.
+   */
+  ATAK_PLUGIN_V2 = 78;
+
+  /*
+   * GroupAlarm integration
+   * Used for transporting GroupAlarm-related messages between Meshtastic nodes
+   * and companion applications/services.
+   */
+  GROUPALARM_APP = 112;
 
   /*
    * Private applications should use portnums >= 256.

--- a/app/src/main/proto/meshtastic/telemetry.proto
+++ b/app/src/main/proto/meshtastic/telemetry.proto
@@ -130,21 +130,21 @@ message EnvironmentMetrics {
   optional float wind_lull = 17;
 
   /*
-  * Radiation in µR/h
-  */
+   * Radiation in µR/h
+   */
   optional float radiation = 18;
 
   /*
-  * Rainfall in the last hour in mm
-  */
+   * Rainfall in the last hour in mm
+   */
   optional float rainfall_1h = 19;
 
-    /*
-  * Rainfall in the last 24 hours in mm
-  */
+  /*
+   * Rainfall in the last 24 hours in mm
+   */
   optional float rainfall_24h = 20;
 
- /*
+  /*
    * Soil moisture measured (% 1-100)
    */
   optional uint32 soil_moisture = 21;
@@ -153,6 +153,11 @@ message EnvironmentMetrics {
    * Soil temperature measured (*C)
    */
   optional float soil_temperature = 22;
+
+  /*
+   * One-wire temperature (*C)
+   */
+  repeated float one_wire_temperature = 23;
 }
 
 /*
@@ -188,6 +193,56 @@ message PowerMetrics {
    * Current (Ch3)
    */
   optional float ch3_current = 6;
+
+  /*
+   * Voltage (Ch4)
+   */
+  optional float ch4_voltage = 7;
+
+  /*
+   * Current (Ch4)
+   */
+  optional float ch4_current = 8;
+
+  /*
+   * Voltage (Ch5)
+   */
+  optional float ch5_voltage = 9;
+
+  /*
+   * Current (Ch5)
+   */
+  optional float ch5_current = 10;
+
+  /*
+   * Voltage (Ch6)
+   */
+  optional float ch6_voltage = 11;
+
+  /*
+   * Current (Ch6)
+   */
+  optional float ch6_current = 12;
+
+  /*
+   * Voltage (Ch7)
+   */
+  optional float ch7_voltage = 13;
+
+  /*
+   * Current (Ch7)
+   */
+  optional float ch7_current = 14;
+
+  /*
+   * Voltage (Ch8)
+   */
+  optional float ch8_voltage = 15;
+
+  /*
+   * Current (Ch8)
+   */
+  optional float ch8_current = 16;
 }
 
 /*
@@ -195,69 +250,129 @@ message PowerMetrics {
  */
 message AirQualityMetrics {
   /*
-   * Concentration Units Standard PM1.0
+   * Concentration Units Standard PM1.0 in ug/m3
    */
   optional uint32 pm10_standard = 1;
 
   /*
-   * Concentration Units Standard PM2.5
+   * Concentration Units Standard PM2.5 in ug/m3
    */
   optional uint32 pm25_standard = 2;
 
   /*
-   * Concentration Units Standard PM10.0
+   * Concentration Units Standard PM10.0 in ug/m3
    */
   optional uint32 pm100_standard = 3;
 
   /*
-   * Concentration Units Environmental PM1.0
+   * Concentration Units Environmental PM1.0 in ug/m3
    */
   optional uint32 pm10_environmental = 4;
 
   /*
-   * Concentration Units Environmental PM2.5
+   * Concentration Units Environmental PM2.5 in ug/m3
    */
   optional uint32 pm25_environmental = 5;
 
   /*
-   * Concentration Units Environmental PM10.0
+   * Concentration Units Environmental PM10.0 in ug/m3
    */
   optional uint32 pm100_environmental = 6;
 
   /*
-   * 0.3um Particle Count
+   * 0.3um Particle Count in #/0.1l
    */
   optional uint32 particles_03um = 7;
 
   /*
-   * 0.5um Particle Count
+   * 0.5um Particle Count in #/0.1l
    */
   optional uint32 particles_05um = 8;
 
   /*
-   * 1.0um Particle Count
+   * 1.0um Particle Count in #/0.1l
    */
   optional uint32 particles_10um = 9;
 
   /*
-   * 2.5um Particle Count
+   * 2.5um Particle Count in #/0.1l
    */
   optional uint32 particles_25um = 10;
 
   /*
-   * 5.0um Particle Count
+   * 5.0um Particle Count in #/0.1l
    */
   optional uint32 particles_50um = 11;
 
   /*
-   * 10.0um Particle Count
+   * 10.0um Particle Count in #/0.1l
    */
   optional uint32 particles_100um = 12;
 
   /*
-   * 10.0um Particle Count
+   * CO2 concentration in ppm
    */
   optional uint32 co2 = 13;
+
+  /*
+   * CO2 sensor temperature in degC
+   */
+  optional float co2_temperature = 14;
+
+  /*
+   * CO2 sensor relative humidity in %
+   */
+  optional float co2_humidity = 15;
+
+  /*
+   * Formaldehyde sensor formaldehyde concentration in ppb
+   */
+  optional float form_formaldehyde = 16;
+
+  /*
+   * Formaldehyde sensor relative humidity in %RH
+   */
+  optional float form_humidity = 17;
+
+  /*
+   * Formaldehyde sensor temperature in degrees Celsius
+   */
+  optional float form_temperature = 18;
+
+  /*
+   * Concentration Units Standard PM4.0 in ug/m3
+   */
+  optional uint32 pm40_standard = 19;
+
+  /*
+   * 4.0um Particle Count in #/0.1l
+   */
+  optional uint32 particles_40um = 20;
+
+  /*
+   * PM Sensor Temperature
+   */
+  optional float pm_temperature = 21;
+
+  /*
+   * PM Sensor humidity
+   */
+  optional float pm_humidity = 22;
+
+  /*
+   * PM Sensor VOC Index
+   */
+  optional float pm_voc_idx = 23;
+
+  /*
+   * PM Sensor NOx Index
+   */
+  optional float pm_nox_idx = 24;
+
+  /*
+   * Typical Particle Size in um
+   */
+  optional float particles_tps = 25;
 }
 
 /*
@@ -318,12 +433,72 @@ message LocalStats {
    * This will always be zero for ROUTERs/REPEATERs. If this number is high, some other node(s) is/are relaying faster than you.
    */
   uint32 num_tx_relay_canceled = 11;
+
+  /*
+   * Number of bytes used in the heap
+   */
+  uint32 heap_total_bytes = 12;
+
+  /*
+   * Number of bytes free in the heap
+   */
+  uint32 heap_free_bytes = 13;
+
+  /*
+   * Number of packets that were dropped because the transmit queue was full.
+   */
+  uint32 num_tx_dropped = 14;
+
+  /*
+   * Noise floor value measured in dBm
+   */
+  int32 noise_floor = 15;
+}
+
+/*
+ * Traffic management statistics for mesh network optimization
+ */
+message TrafficManagementStats {
+  /*
+   * Total number of packets inspected by traffic management
+   */
+  uint32 packets_inspected = 1;
+
+  /*
+   * Number of position packets dropped due to deduplication
+   */
+  uint32 position_dedup_drops = 2;
+
+  /*
+   * Number of NodeInfo requests answered from cache
+   */
+  uint32 nodeinfo_cache_hits = 3;
+
+  /*
+   * Number of packets dropped due to rate limiting
+   */
+  uint32 rate_limit_drops = 4;
+
+  /*
+   * Number of unknown/undecryptable packets dropped
+   */
+  uint32 unknown_packet_drops = 5;
+
+  /*
+   * Number of packets with hop_limit exhausted for local-only broadcast
+   */
+  uint32 hop_exhausted_packets = 6;
+
+  /*
+   * Number of times router hop preservation was applied
+   */
+  uint32 router_hops_preserved = 7;
 }
 
 /*
  * Health telemetry metrics
  */
- message HealthMetrics {
+message HealthMetrics {
   /*
    * Heart rate (beats per minute)
    */
@@ -338,6 +513,57 @@ message LocalStats {
    * Body temperature in degrees Celsius
    */
   optional float temperature = 3;
+}
+
+/*
+ * Linux host metrics
+ */
+message HostMetrics {
+  /*
+   * Host system uptime
+   */
+  uint32 uptime_seconds = 1;
+
+  /*
+   * Host system free memory
+   */
+  uint64 freemem_bytes = 2;
+
+  /*
+   * Host system disk space free for /
+   */
+  uint64 diskfree1_bytes = 3;
+
+  /*
+   * Secondary system disk space free
+   */
+  optional uint64 diskfree2_bytes = 4;
+
+  /*
+   * Tertiary disk space free
+   */
+  optional uint64 diskfree3_bytes = 5;
+
+  /*
+   * Host system one minute load in 1/100ths
+   */
+  uint32 load1 = 6;
+
+  /*
+   * Host system five minute load  in 1/100ths
+   */
+  uint32 load5 = 7;
+
+  /*
+   * Host system fifteen minute load  in 1/100ths
+   */
+  uint32 load15 = 8;
+
+  /*
+   * Optional User-provided string for arbitrary host system information
+   * that doesn't make sense as a dedicated entry.
+   */
+  optional string user_string = 9;
 }
 
 /*
@@ -379,6 +605,16 @@ message Telemetry {
      * Health telemetry metrics
      */
     HealthMetrics health_metrics = 7;
+
+    /*
+     * Linux host metrics
+     */
+    HostMetrics host_metrics = 8;
+
+    /*
+     * Traffic management statistics
+     */
+    TrafficManagementStats traffic_management_stats = 9;
   }
 }
 
@@ -422,7 +658,7 @@ enum TelemetrySensorType {
   BMP280 = 6;
 
   /*
-   * High accuracy temperature and humidity
+   * TODO - REMOVE High accuracy temperature and humidity
    */
   SHTC3 = 7;
 
@@ -447,7 +683,7 @@ enum TelemetrySensorType {
   QMC5883L = 11;
 
   /*
-   * High accuracy temperature and humidity
+   * TODO - REMOVE High accuracy temperature and humidity
    */
   SHT31 = 12;
 
@@ -472,7 +708,7 @@ enum TelemetrySensorType {
   RCWL9620 = 16;
 
   /*
-   * Sensirion High accuracy temperature and humidity
+   * TODO - REMOVE Sensirion High accuracy temperature and humidity
    */
   SHT4X = 17;
 
@@ -575,6 +811,86 @@ enum TelemetrySensorType {
    * RAKWireless RAK12035 Soil Moisture Sensor Module
    */
   RAK12035 = 37;
+
+  /*
+   * MAX17261 lipo battery gauge
+   */
+  MAX17261 = 38;
+
+  /*
+   * PCT2075 Temperature Sensor
+   */
+  PCT2075 = 39;
+
+  /*
+   * ADS1X15 ADC
+   */
+  ADS1X15 = 40;
+
+  /*
+   * ADS1X15 ADC_ALT
+   */
+  ADS1X15_ALT = 41;
+
+  /*
+   * Sensirion SFA30 Formaldehyde sensor
+   */
+  SFA30 = 42;
+
+  /*
+   * SEN5X PM SENSORS
+   */
+  SEN5X = 43;
+
+  /*
+   * TSL2561 light sensor
+   */
+  TSL2561 = 44;
+
+  /*
+   * BH1750 light sensor
+   */
+  BH1750 = 45;
+
+  /*
+   * HDC1080 Temperature and Humidity Sensor
+   */
+  HDC1080 = 46;
+
+  /*
+   * TODO - REMOVE STH21 Temperature and R. Humidity sensor
+   */
+  SHT21 = 47;
+
+  /*
+   * Sensirion STC31 CO2 sensor
+   */
+  STC31 = 48;
+
+  /*
+   * SCD30 CO2, humidity, temperature sensor
+   */
+  SCD30 = 49;
+
+  /*
+   * SHT family of sensors for temperature and humidity
+   */
+  SHTXX = 50;
+
+  /*
+   * DS248X Bridge for one-wire temperature sensors
+   */
+  DS248X = 51;
+
+  /*
+   * MMC5983MA 3-Axis Digital Magnetic Sensor
+   */
+  MMC5983MA = 52;
+
+  /*
+   * ICM-42607-P 6‑Axis IMU
+   */
+  ICM42607P = 53;
 }
 
 /*
@@ -590,4 +906,39 @@ message Nau7802Config {
    * The calibration factor for the NAU7802
    */
   float calibrationFactor = 2;
+}
+
+/*
+ * SEN5X State, for saving to flash
+ */
+message SEN5XState {
+  /*
+   * Last cleaning time for SEN5X
+   */
+  uint32 last_cleaning_time = 1;
+
+  /*
+   * Last cleaning time for SEN5X - valid flag
+   */
+  bool last_cleaning_valid = 2;
+
+  /*
+   * Config flag for one-shot mode (see admin.proto)
+   */
+  bool one_shot_mode = 3;
+
+  /*
+   * Last VOC state time for SEN55
+   */
+  optional uint32 voc_state_time = 4;
+
+  /*
+   * Last VOC state validity flag for SEN55
+   */
+  optional bool voc_state_valid = 5;
+
+  /*
+   * VOC state array (8x uint8t) for SEN55
+   */
+  optional fixed64 voc_state_array = 6;
 }

--- a/app/src/main/res/layout/meshtastic_layout.xml
+++ b/app/src/main/res/layout/meshtastic_layout.xml
@@ -531,6 +531,43 @@
 
                         </LinearLayout>
 
+                        <!-- Lockdown (hardened-firmware) controls -->
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical"
+                            android:background="#FF2A2A2A"
+                            android:padding="12dp"
+                            android:layout_marginBottom="8dp">
+
+                            <TextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:text="Device Lockdown"
+                                android:textSize="16sp"
+                                android:textColor="#FFFFFF"
+                                android:textStyle="bold"
+                                android:paddingBottom="4dp" />
+
+                            <TextView
+                                android:id="@+id/lockdown_status_text"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:text="Status: unknown"
+                                android:textSize="12sp"
+                                android:textColor="#FFAAAAAA"
+                                android:paddingBottom="8dp" />
+
+                            <Button
+                                android:id="@+id/btn_lock_now"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:text="Lock Now"
+                                android:textColor="#FFFFFF"
+                                android:backgroundTint="#FFCC3333" />
+
+                        </LinearLayout>
+
 
                     </LinearLayout>
                 </ScrollView>


### PR DESCRIPTION
## Summary

- **Lockdown support** for MESHTASTIC_LOCKDOWN-hardened firmware ([firmware PR #10349](https://github.com/meshtastic/firmware/pull/10349)), driven by the typed proto wire format from [meshtastic/protobufs PR #911](https://github.com/meshtastic/protobufs/pull/911):
  - `LockdownCoordinator` drives a per-BLE-connection state machine off `FromRadio.lockdown_status`.
  - Auto-replays cached passphrase silently on `LOCKED`; only prompts on `NEEDS_PROVISION` or auto-replay failure.
  - Passphrase cache keyed by BLE MAC in `EncryptedSharedPreferences` (AES-256-GCM Keystore master key).
  - Outbound `AdminMessage.lockdown_auth` packet builder enforces firmware ToRadio gate: `to=myNodeNum`, `from=0`, `portnum=ADMIN_APP`, `hop_limit/start=7`, `priority=RELIABLE`, no `pki_encrypted`.
  - Lock Now races: synthesizes `LockNowAcknowledged` on the next inbound `LOCKED` status (or on BLE disconnect if status races the reboot).
  - UI: passphrase dialog with optional boots / hours TTL overrides, Lock Now button, backoff countdown.

- **Region fix:** TAK auto-config previously hardcoded `EU_868`; now sets `US`.

- **UI refresh fix:** Device Information card now re-renders automatically when a fresh Config response is cached (fixes the "region still shows old value until I disconnect/reconnect" UX bug).

- **Proto upgrade:** Full sync from `meshtastic/protobufs` master commit `1c62540` (the merge of PR #911). `java_package` overridden to `com.geeksville.mesh` so existing Kotlin/Java references continue to work; firmware-only protos that transitively pull in `nanopb.proto` were dropped.

- **Version bump:** `PLUGIN_VERSION` 0.2 → 1.0 for TAK TPP signing submission.

## Test plan

- [x] Builds (`gradle :app:assembleCivDebug`) — clean compile, generated `AdminProtos.LockdownAuth` + `MeshProtos.LockdownStatus`.
- [x] Installed civDebug APK on test ATAK device; auto-configured a Meshtastic node from EU_868 → US (verified with `meshtastic --info`).
- [x] Device Information card refreshes region after auto-config reboot without manual disconnect/reconnect.
- [ ] Provision flow on a hardened lockdown device (no hardened test device available locally).
- [ ] Wrong-passphrase + backoff display on a hardened lockdown device.
- [ ] Lock Now ack flow on a hardened lockdown device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)